### PR TITLE
Fix build

### DIFF
--- a/conf/builder.conf
+++ b/conf/builder.conf
@@ -129,7 +129,9 @@ define([TE_AGENT_BUILD], [
                       [\${EXT_SOURCES}/build.sh],
                       [nfq_daemon/nfq_daemon \
                        apprtt/ol-apprtt \
-                       ceph/ol-ceph])
+                      # ol-ceph building is disabled. See gpl_tools/meson.build
+                      # ceph/ol-ceph \
+                      ])
 
         fi
     fi

--- a/conf/builder.conf
+++ b/conf/builder.conf
@@ -123,14 +123,13 @@ define([TE_AGENT_BUILD], [
 
             # By this macro the applications from gpl_tools directory
             # are built and deployed.
+            # ol-ceph building is disabled. See gpl_tools/meson.build
             TE_TA_APP([gpl_tools], [${$1_TA_TYPE}], [${$1_TA_TYPE}],
                       [${SOCKAPI_TS_LIBDIR}/gpl_tools], [], [],
                       [logger_core tools],
                       [\${EXT_SOURCES}/build.sh],
                       [nfq_daemon/nfq_daemon \
                        apprtt/ol-apprtt \
-                      # ol-ceph building is disabled. See gpl_tools/meson.build
-                      # ceph/ol-ceph \
                       ])
 
         fi

--- a/conf/builder.conf
+++ b/conf/builder.conf
@@ -4,7 +4,6 @@ include(builder.part.linux.platform)
 
 TE_PLATFORM([], [], [-D_GNU_SOURCE], [-D_GNU_SOURCE], [],
             [logger_core tools logic_expr conf_oid rpcxdr rpc_types asn ndn \
-             tce \
              ipc bsapi loggerten rcfapi confapi comm_net_engine rcfunix \
              tapi rcfrpc tapi_rpc tapi_env tapi_tad log_proc trc \
              tapi_tcp_states tapi_bpf tapi_serial tapi_job tapi_tool])

--- a/conf/builder.conf
+++ b/conf/builder.conf
@@ -84,7 +84,7 @@ define([TE_AGENT_BUILD], [
                 TE_PLATFORM_EXT([libbpf], [${$1_TA_TYPE}], [${TE_LIBBPF_SRC}], [], [],
                                 [export OBJDIR=\${PWD} && make -C \${EXT_SOURCES}/src],
                                 [\${EXT_SOURCES}/src/bpf.h \${EXT_SOURCES}/src/libbpf_common.h \${EXT_SOURCES}/src/libbpf.h],
-                                [libbpf.so], [])
+                                [libbpf.so], [], [], [bpf])
             fi
 
             TE_LIB_PARMS([tad], [${$1_TA_TYPE}], [],

--- a/gpl_tools/lib/ol_helpers.c
+++ b/gpl_tools/lib/ol_helpers.c
@@ -190,5 +190,12 @@ ol_create_and_connect_socket(ol_connection_type conn_type, int sock_type,
 void
 ol_hex_diff_dump(const uint8_t  *ex_pkt, const uint8_t *rx_pkt, size_t size)
 {
-    te_hex_diff_dump(ex_pkt, rx_pkt, size, puts);
+    te_string buf = TE_STRING_INIT;
+
+    te_hex_diff_dump(ex_pkt, size, rx_pkt, size, 0, &buf);
+    fputs(buf.ptr, stdout);
+    if (buf.len == 0 || buf.ptr[buf.len - 1] != '\n')
+        fputc('\n', stdout);
+
+    te_string_free(&buf);
 }

--- a/gpl_tools/meson.build
+++ b/gpl_tools/meson.build
@@ -29,7 +29,10 @@ subdir('lib')
 # Build apps
 apps = [
     'apprtt',
-    'ceph',
+    # ol-ceph tool contains original ceph headers which break sapi-ts building
+    # with gcc 11.3.0. We do not want to maintain ceph headers, so just disable
+    # the ol-ceph building.
+    # 'ceph',
     'nfq_daemon',
 ]
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -58,7 +58,7 @@ exit 1
 
 L5_RUN=false
 ZF_SHIM_RUN=false
-RUN_OPTS="${RUN_OPTS} --trc-comparison=normalised --build-meson"
+RUN_OPTS="${RUN_OPTS} --trc-comparison=normalised"
 RUN_OPTS="${RUN_OPTS} --sniff-not-feed-conf"
 RUN_OPTS="${RUN_OPTS} --tester-only-req-logues"
 do_item=true

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -7,7 +7,7 @@ pushd "$(dirname "$(which "$0")")" >/dev/null
 RUNDIR="$(pwd -P)"
 popd >/dev/null
 
-[ "$(basename $RUNDIR)" = "scripts" ] && RUNDIR="${RUNDIR}/.."
+[ "$(basename $RUNDIR)" = "scripts" ] && RUNDIR="$(realpath "${RUNDIR}/..")"
 [ -e "${RUNDIR}/scripts/guess.sh" ] && source "${RUNDIR}/scripts/guess.sh"
 
 . ${SF_TS_CONFDIR}/scripts/lib.run

--- a/sockapi-ts/epilogue.c
+++ b/sockapi-ts/epilogue.c
@@ -14,7 +14,6 @@
 #define TE_TEST_NAME    "epilogue"
 
 #include "sockapi-test.h"
-#include "tce_api.h"
 #include "tapi_proc.h"
 #include "lib-ts_netns.h"
 #include "onload.h"
@@ -133,7 +132,6 @@ main(int argc, char **argv)
     char            name[SOCKTS_LEAK_FNAME_MAX_LEN];
     char            name_p[SOCKTS_LEAK_FNAME_MAX_LEN];
 
-    char           *do_tce = getenv("SF_V5_DO_TCE");
     char           *check_zombie_stacks =
                         getenv("SF_V5_CHECK_ZOMBIE_STACKS");
     char           *kill_zombie_stacks =
@@ -175,9 +173,6 @@ main(int argc, char **argv)
      * 1. avoid Onload acceleration of pco_iut;
      * 2. make sure RPC server is in adequate state. */
     CHECK_RC(rcf_rpc_server_restart(pco_iut));
-
-    if (do_tce != NULL && strcmp(do_tce, "no") != 0)
-        CHECK_RC(tce_retrieve_data(pco_iut));
 
     stop_nfqueue(pco_tst);
 

--- a/sockapi-ts/epoll/epoll_one_shot.c
+++ b/sockapi-ts/epoll/epoll_one_shot.c
@@ -164,7 +164,7 @@ main(int argc, char *argv[])
         else
         {
 #define UDP_SEND_PACKETS 10000
-            int         vector[UDP_SEND_PACKETS];
+            tarpc_size_t vector[UDP_SEND_PACKETS];
             uint64_t    size;
             int         i;
 

--- a/sockapi-ts/level5/extension/zc_register_bufs.c
+++ b/sockapi-ts/level5/extension/zc_register_bufs.c
@@ -172,7 +172,7 @@ consume_existing_thpages(rcf_rpc_server *pco_iut,
     for (i = 0; i < MAX_THPAGES; i++)
     {
         pco_iut->silent_pass = TRUE;
-        thp_bufs[i] = rpc_memalign(pco_iut, size, size);
+        rpc_posix_memalign(pco_iut, &thp_bufs[i], size, size);
 
         pco_iut->silent_pass = TRUE;
         rpc_madvise(pco_iut, thp_bufs[i], size, RPC_MADV_HUGEPAGE);
@@ -311,7 +311,7 @@ main(int argc, char *argv[])
     }
     else
     {
-        buf_ptr = rpc_memalign(pco_iut, page_size, real_len);
+        rpc_posix_memalign(pco_iut, &buf_ptr, page_size, real_len);
         if (huge_pages == HUGE_PAGES_TRANSPARENT)
             rpc_madvise(pco_iut, buf_ptr, real_len, RPC_MADV_HUGEPAGE);
     }
@@ -406,7 +406,7 @@ main(int argc, char *argv[])
                 TEST_SUBSTEP("If the sum did not increase, try to allocate "
                              "a new buffer, change its contents and "
                              "recheck.");
-                buf_ptr_aux = rpc_memalign(pco_iut, page_size, real_len);
+                rpc_posix_memalign(pco_iut, &buf_ptr_aux, page_size, real_len);
                 rpc_madvise(pco_iut, buf_ptr_aux, real_len,
                             RPC_MADV_HUGEPAGE);
                 rpc_set_buf(pco_iut, &test_byte, 1, buf_ptr_aux);

--- a/sockapi-ts/level5/extension/zc_send_user_buf_overfill.c
+++ b/sockapi-ts/level5/extension/zc_send_user_buf_overfill.c
@@ -166,7 +166,7 @@ main(int argc, char *argv[])
               "of size which is multiple of system page size and is "
               "larger than available space in send socket buffer on IUT "
               "plus receive socket buffer on Tester.");
-    buf_ptr = rpc_memalign(pco_iut, sys_page_size, alloc_size);
+    rpc_posix_memalign(pco_iut, &buf_ptr, sys_page_size, alloc_size);
 
     TEST_STEP("Register the allocated buffer with "
               "@b onload_zc_register_buffers().");

--- a/sockapi-ts/lib/sendfile_common.h
+++ b/sockapi-ts/lib/sendfile_common.h
@@ -93,7 +93,7 @@
         strncpy(path_name + strlen(path_name), (file_name_),            \
                 sizeof(path_name) - strlen(path_name));                 \
                                                                         \
-        if (tapi_file_ta_unlink_fmt((ta_), path_name) != 0)             \
+        if (tapi_file_ta_unlink_fmt((ta_), "%s", path_name) != 0)       \
         {                                                               \
             result = EXIT_FAILURE;                                      \
         }                                                               \

--- a/sockapi-ts/lib/sockapi-ts_rpc.c
+++ b/sockapi-ts/lib/sockapi-ts_rpc.c
@@ -67,7 +67,7 @@ rpc_sapi_get_sizeof(rcf_rpc_server *rpcs, const char *type_name)
 
 int
 rpc_send_traffic(rcf_rpc_server *rpcs, int num,
-                 int *s, const void *buf, size_t len,
+                 int *s, const void *buf, tarpc_size_t len,
                  int flags, struct sockaddr *to)
 {
     tarpc_send_traffic_in  in;
@@ -154,7 +154,7 @@ rpc_send_traffic(rcf_rpc_server *rpcs, int num,
 
 int
 rpc_many_sendto(rcf_rpc_server *rpcs, int num,
-                int s, size_t len, int flags,
+                int s, tarpc_size_t len, int flags,
                 const struct sockaddr *to, uint64_t *sent)
 {
     tarpc_many_sendto_in  in;
@@ -328,7 +328,7 @@ rpc_close_and_socket(rcf_rpc_server *rpcs, int fd,
 
 int
 rpc_timely_round_trip(rcf_rpc_server *rpcs, int sock_num, int *s,
-                      size_t size, size_t vector_len,
+                      tarpc_size_t size, tarpc_size_t vector_len,
                       uint32_t timeout, uint32_t time2wait,
                       int flags, int addr_num, struct sockaddr *to)
 {
@@ -453,7 +453,7 @@ rpc_timely_round_trip(rcf_rpc_server *rpcs, int sock_num, int *s,
     
 int
 rpc_round_trip_echoer(rcf_rpc_server *rpcs, int sock_num, int *s,
-                      int addr_num, size_t size, size_t vector_len,
+                      int addr_num, tarpc_size_t size, tarpc_size_t vector_len,
                       uint32_t timeout, int flags)
 {
     int       *ss; 
@@ -571,10 +571,10 @@ blk_aio_mode_rpc2str(tarpc_blocking_aio_mode mode)
  *
  * @return  number of bytes read, otherwise -1 on error.
  */
-ssize_t 
+tarpc_ssize_t
 rpc_aio_read_blk_gen(rcf_rpc_server *rpcs,
-                     int s, void *buf, size_t len,
-                     tarpc_blocking_aio_mode mode, size_t rbuflen)
+                     int s, void *buf, tarpc_size_t len,
+                     tarpc_blocking_aio_mode mode, tarpc_size_t rbuflen)
 {
     tarpc_aio_read_blk_in  in;
     tarpc_aio_read_blk_out out;
@@ -629,9 +629,9 @@ rpc_aio_read_blk_gen(rcf_rpc_server *rpcs,
  *
  * @return Number of bytes received, otherwise -1 when error occured
  */
-ssize_t 
+tarpc_ssize_t
 rpc_aio_write_blk(rcf_rpc_server *rpcs,
-                  int s, const void *buf, size_t len, 
+                  int s, const void *buf, tarpc_size_t len,
                   tarpc_blocking_aio_mode mode)
 {
     tarpc_aio_write_blk_in  in;
@@ -743,7 +743,7 @@ rpc_nested_requests_test(rcf_rpc_server *rpcs, int s, int req_num)
 
 void
 rpc_write_at_offset_continuous(rcf_rpc_server *rpcs, int fd, char* buf,
-                               size_t buflen, off_t offset, uint64_t time)
+                               tarpc_size_t buflen, off_t offset, uint64_t time)
 {
     struct tarpc_write_at_offset_continuous_in  in;
     struct tarpc_write_at_offset_continuous_out out;
@@ -1086,8 +1086,8 @@ rpc_get_socket_from_array(rcf_rpc_server *rpcs, rpc_ptr handle,
 }
 
 int
-rpc_many_recv(rcf_rpc_server *rpcs, int sock, size_t length, int num,
-              int duration, void *last_packet, size_t last_packet_len,
+rpc_many_recv(rcf_rpc_server *rpcs, int sock, tarpc_size_t length, int num,
+              int duration, void *last_packet, tarpc_size_t last_packet_len,
               te_bool count_fails, int *fails_num)
 {
     struct tarpc_many_recv_in  in;
@@ -1119,8 +1119,8 @@ rpc_many_recv(rcf_rpc_server *rpcs, int sock, size_t length, int num,
 }
 
 int
-rpc_many_send_num_func(rcf_rpc_server *rpcs, int sock, size_t length_min,
-                       size_t length_max, int num, int duration,
+rpc_many_send_num_func(rcf_rpc_server *rpcs, int sock, tarpc_size_t length_min,
+                       tarpc_size_t length_max, int num, int duration,
                        const char *func_name, te_bool check_len,
                        te_bool count_fails, int *fails_num)
 {
@@ -1834,9 +1834,9 @@ rpc_onload_zc_unregister_buffers(rcf_rpc_server *rpcs,
 }
 
 /* See description in sockapi-ts_rpc.h */
-ssize_t
+tarpc_ssize_t
 rpc_onload_zc_send_msg_more(rcf_rpc_server *rpcs, int s, rpc_ptr buf,
-                            size_t first_len, size_t second_len,
+                            tarpc_size_t first_len, tarpc_size_t second_len,
                             te_bool first_zc, te_bool second_zc,
                             te_bool use_reg_bufs,
                             te_bool set_nodelay)
@@ -1970,7 +1970,7 @@ onload_zc_mmsg_rpc2str(rcf_rpc_server *rpcs,
                        struct rpc_onload_zc_mmsg *mmsg, te_string *str)
 {
     te_errno rc = 0;
-    size_t i;
+    tarpc_size_t i;
 
     rc = te_string_append(str, "{ ");
     if (rc != 0)
@@ -2461,7 +2461,7 @@ rpc_simple_zc_recv_gen(rcf_rpc_server *rpcs, int s,
 }
 
 /* See description in the sockapi-ts_rpc.h */
-ssize_t
+tarpc_ssize_t
 rpc_simple_hlrx_recv_zc(rcf_rpc_server *rpcs,
                         int s, struct rpc_msghdr *msg,
                         rpc_send_recv_flags flags,
@@ -2532,13 +2532,13 @@ rpc_simple_hlrx_recv_zc(rcf_rpc_server *rpcs,
                  s, msg, msghdr_rpc2str(msg, &str_msg),
                  send_recv_flags_rpc2str(flags),
                  (os_inline ? "TRUE" : "FALSE"),
-                 (ssize_t)(out.retval));
+                 (tarpc_ssize_t)(out.retval));
 
     RETVAL_INT(simple_hlrx_recv_zc, out.retval);
 }
 
 /* See description in the sockapi-ts_rpc.h */
-extern ssize_t
+extern tarpc_ssize_t
 rpc_simple_hlrx_recv_copy(rcf_rpc_server *rpcs,
                           int s, struct rpc_msghdr *msg,
                           rpc_send_recv_flags flags,
@@ -2610,7 +2610,7 @@ rpc_simple_hlrx_recv_copy(rcf_rpc_server *rpcs,
                  s, msg, msghdr_rpc2str(msg, &str_msg),
                  send_recv_flags_rpc2str(flags),
                  (os_inline ? "TRUE" : "FALSE"),
-                 (ssize_t)(out.retval));
+                 (tarpc_ssize_t)(out.retval));
 
     RETVAL_INT(simple_hlrx_recv_copy, out.retval);
 }
@@ -2644,9 +2644,9 @@ rpc_onload_set_recv_filter_capture(rcf_rpc_server *rpcs, int s, int flags)
 }
 
 /* See description in the sockapi-ts_rpc.h */
-ssize_t
+tarpc_ssize_t
 rpc_sockts_recv_filtered_pkt(rcf_rpc_server *rpcs, int s,
-                             char *buf, size_t len)
+                             char *buf, tarpc_size_t len)
 {
     tarpc_sockts_recv_filtered_pkt_in  in;
     tarpc_sockts_recv_filtered_pkt_out out;
@@ -2706,7 +2706,7 @@ rpc_sockts_recv_filtered_pkts_clear(rcf_rpc_server *rpcs)
 
 int
 rpc_simple_set_recv_filter(rcf_rpc_server *rpcs, int s, const void *buf,
-                           size_t len, int flags)
+                           tarpc_size_t len, int flags)
 {
     tarpc_simple_set_recv_filter_in  in;
     tarpc_simple_set_recv_filter_out out;
@@ -2738,10 +2738,10 @@ rpc_simple_set_recv_filter(rcf_rpc_server *rpcs, int s, const void *buf,
 }
 
 void
-iov_h2rpc(struct tarpc_iovec* iov_arr, const rpc_iovec* iov, size_t iovcnt,
+iov_h2rpc(struct tarpc_iovec* iov_arr, const rpc_iovec* iov, tarpc_size_t iovcnt,
           char *strbuf, int strbuf_len)
 {
-    size_t i;
+    tarpc_size_t i;
 
     memset(strbuf, 0, strbuf_len);
     snprintf(strbuf, strbuf_len, "{");
@@ -2774,7 +2774,7 @@ static int
 rpc_onload_msg_template_in_init(tarpc_onload_msg_template_alloc_in *in,
                                 rcf_rpc_server *rpcs, int fd,
                                 struct tarpc_iovec *iov_arr, rpc_iovec* iov,
-                                size_t iovcnt, size_t riovcnt,
+                                tarpc_size_t iovcnt, tarpc_size_t riovcnt,
                                 rpc_onload_template_handle* handle,
                                 int flags)
 {
@@ -2815,7 +2815,7 @@ rpc_onload_msg_template_in_init(tarpc_onload_msg_template_alloc_in *in,
 /* See description in the sockapi-ts_rpc.h */
 int
 rpc_onload_msg_template_alloc_gen(rcf_rpc_server *rpcs, int fd,
-                              rpc_iovec* iov, size_t iovcnt, size_t riovcnt,
+                              rpc_iovec* iov, tarpc_size_t iovcnt, tarpc_size_t riovcnt,
                               rpc_onload_template_handle* handle,
                               int flags)
 {
@@ -2878,13 +2878,13 @@ int
 rpc_onload_msg_template_update_gen(rcf_rpc_server *rpcs, int fd,
                               rpc_onload_template_handle handle,
                               rpc_onload_template_msg_update_iovec *updates,
-                              size_t iovcnt, size_t riovcnt, int flags)
+                              tarpc_size_t iovcnt, tarpc_size_t riovcnt, int flags)
 {
     tarpc_onload_msg_template_update_in     in;
     tarpc_onload_msg_template_update_out    out;
     tarpc_onload_template_msg_update_iovec  upd_arr[RCF_RPC_MAX_IOVEC];
 
-    size_t  i;
+    tarpc_size_t  i;
 
     memset(&in, 0, sizeof(in));
     memset(&out, 0, sizeof(out));
@@ -2938,7 +2938,7 @@ rpc_onload_msg_template_update_gen(rcf_rpc_server *rpcs, int fd,
 /* See description in the sockapi-ts_rpc.h */
 int
 rpc_template_send(rcf_rpc_server *rpcs, int fd, rpc_iovec* iov,
-                  size_t iovcnt, size_t riovcnt, int flags)
+                  tarpc_size_t iovcnt, tarpc_size_t riovcnt, int flags)
 {
     tarpc_template_send_in  in;
     tarpc_template_send_out out;
@@ -3014,7 +3014,7 @@ rpc_popen_flooder_toggle(rcf_rpc_server *rpcs, te_bool enable)
 static void
 oo_epollevt2str(struct rpc_epoll_event *evts,
                 rpc_onload_ordered_epoll_event *oo_events,
-                int n_evts, char *buf, size_t buflen)
+                int n_evts, char *buf, tarpc_size_t buflen)
 {
     int i;
     int rc;
@@ -3027,7 +3027,7 @@ oo_epollevt2str(struct rpc_epoll_event *evts,
 
     do {
         rc = snprintf(buf, buflen, "{");
-        if ((size_t)rc > buflen)
+        if ((tarpc_size_t)rc > buflen)
             break;
         buflen -= rc;
         buf += rc;
@@ -3039,13 +3039,13 @@ oo_epollevt2str(struct rpc_epoll_event *evts,
                           (long)oo_events[i].ts.tv_sec,
                           oo_events[i].ts.tv_nsec,
                           epoll_event_rpc2str(evts[i].events));
-            if ((size_t)rc > buflen)
+            if ((tarpc_size_t)rc > buflen)
                 break;
             buflen -= rc;
             buf += rc;
         }
         rc = snprintf(buf, buflen, "}");
-        if ((size_t)rc > buflen)
+        if ((tarpc_size_t)rc > buflen)
             break;
         buflen -= rc;
         buf += rc;
@@ -3145,8 +3145,8 @@ rpc_onload_ordered_epoll_wait_gen(rcf_rpc_server *rpcs, int epfd,
 int rpc_send_msg_warm_flow(rcf_rpc_server *rpcs,
                            const char *func_name,
                            int fd1, int fd2,
-                           size_t buf_size_min,
-                           size_t buf_size_max,
+                           tarpc_size_t buf_size_min,
+                           tarpc_size_t buf_size_max,
                            unsigned int time2run,
                            uint64_t *sent1, uint64_t *sent2)
 {
@@ -3197,8 +3197,8 @@ int rpc_send_msg_warm_flow(rcf_rpc_server *rpcs,
 /* See decription in sockapi-ts_rpc.h */
 int
 rpc_many_send_cork(rcf_rpc_server *rpcs, int fd, int fd_aux,
-                   size_t size_min, size_t size_max, size_t send_num,
-                   size_t length, int send_usleep, te_bool tcp_nodelay,
+                   tarpc_size_t size_min, tarpc_size_t size_max, tarpc_size_t send_num,
+                   tarpc_size_t length, int send_usleep, te_bool tcp_nodelay,
                    te_bool no_trigger)
 {
     tarpc_many_send_cork_in  in;
@@ -3233,9 +3233,9 @@ rpc_many_send_cork(rcf_rpc_server *rpcs, int fd, int fd_aux,
 }
 
 /* See decription in sockapi-ts_rpc.h */
-ssize_t
+tarpc_ssize_t
 rpc_recv_timing(rcf_rpc_server *rpcs, int fd, int fd_aux,
-                size_t length, uint64_t *duration)
+                tarpc_size_t length, uint64_t *duration)
 {
     tarpc_recv_timing_in  in;
     tarpc_recv_timing_out out;
@@ -3474,7 +3474,7 @@ static const char *recv_func2str(tarpc_recv_function f)
 int
 rpc_send_var_size(rcf_rpc_server *rpcs,
                   tarpc_send_function send_func,
-                  int s, size_t len,
+                  int s, tarpc_size_t len,
                   rpc_send_recv_flags flags,
                   const struct sockaddr *addr)
 {
@@ -3511,7 +3511,7 @@ rpc_send_var_size(rcf_rpc_server *rpcs,
 int
 rpc_recv_var_size(rcf_rpc_server *rpcs,
                   tarpc_recv_function recv_func,
-                  int s, size_t len,
+                  int s, tarpc_size_t len,
                   rpc_send_recv_flags flags)
 {
     tarpc_recv_var_size_in in;
@@ -3567,7 +3567,7 @@ rpc_sockts_alloc_send_func_ctx(rcf_rpc_server *rpcs)
 int
 rpc_sockts_send_func_ctx_init_zc_buf(rcf_rpc_server *rpcs,
                                      rpc_ptr ctx, int fd,
-                                     size_t buf_size)
+                                     tarpc_size_t buf_size)
 {
     tarpc_sockts_send_func_ctx_init_zc_buf_in     in;
     tarpc_sockts_send_func_ctx_init_zc_buf_out    out;

--- a/sockapi-ts/lib/sockapi-ts_rpc.c
+++ b/sockapi-ts/lib/sockapi-ts_rpc.c
@@ -198,7 +198,7 @@ rpc_many_sendto(rcf_rpc_server *rpcs, int num,
 
 int
 rpc_many_send(rcf_rpc_server *rpcs, int sock, int flags,
-              const int *vector, int nops, uint64_t *sent)
+              const tarpc_size_t *vector, int nops, uint64_t *sent)
 {
     tarpc_many_send_in  in;
     tarpc_many_send_out out;

--- a/sockapi-ts/lib/sockapi-ts_rpc.h
+++ b/sockapi-ts/lib/sockapi-ts_rpc.h
@@ -79,7 +79,7 @@ extern tarpc_ssize_t rpc_sapi_get_sizeof(rcf_rpc_server *rpcs,
  * @return 0 in case of success, -1 in case of failure
  */ 
 extern int rpc_send_traffic(rcf_rpc_server *handle, int num, int *s,
-                            const void *buf, size_t len, int flags,
+                            const void *buf, tarpc_size_t len, int flags,
                             struct sockaddr *to);
 
 /**
@@ -111,7 +111,7 @@ extern int rpc_many_send(rcf_rpc_server *handle, int sock, int flags,
  *
  * @return   -1 in the case of failure or 0 on success
  */
-extern int rpc_many_sendto(rcf_rpc_server *rpcs, int num, int s, size_t len,
+extern int rpc_many_sendto(rcf_rpc_server *rpcs, int num, int s, tarpc_size_t len,
                            int flags, const struct sockaddr *to,
                            uint64_t *sent);
 /**
@@ -143,7 +143,7 @@ extern int rpc_many_sendto(rcf_rpc_server *rpcs, int num, int s, size_t len,
  *                             (memory allocation etc.)
  */ 
 extern int rpc_timely_round_trip(rcf_rpc_server *rpcs, int sock_num, int *s,
-                                 size_t size, size_t vector_len,
+                                 tarpc_size_t size, tarpc_size_t vector_len,
                                  uint32_t timeout, uint32_t time2wait,
                                  int flags, int addr_num, 
                                  struct sockaddr *to);
@@ -173,8 +173,8 @@ extern int rpc_timely_round_trip(rcf_rpc_server *rpcs, int sock_num, int *s,
  *                              (memory allocation etc.)
  */ 
 extern int rpc_round_trip_echoer(rcf_rpc_server *rpcs, int sock_num, int *s,
-                                 int addr_num, size_t size, 
-                                 size_t vector_len,
+                                 int addr_num, tarpc_size_t size,
+                                 tarpc_size_t vector_len,
                                  uint32_t timeout, int flags);
 
 /**
@@ -230,10 +230,10 @@ extern int rpc_close_and_socket(rcf_rpc_server *rpcs, int fd,
  *
  * @return  number of bytes read, otherwise -1 on error.
  */
-extern ssize_t rpc_aio_read_blk_gen(rcf_rpc_server *rpcs,
-                                    int s, void *buf, size_t len,
+extern tarpc_ssize_t rpc_aio_read_blk_gen(rcf_rpc_server *rpcs,
+                                    int s, void *buf, tarpc_size_t len,
                                     tarpc_blocking_aio_mode mode, 
-                                    size_t rbuflen);
+                                    tarpc_size_t rbuflen);
 
 /**
  * Emulate blocking reading using AIO requests.
@@ -246,9 +246,9 @@ extern ssize_t rpc_aio_read_blk_gen(rcf_rpc_server *rpcs,
  *
  * @return Number of bytes received, otherwise -1 when error occured
  */
-static inline ssize_t
+static inline tarpc_ssize_t
 rpc_aio_read_blk(rcf_rpc_server *rpcs,
-                 int s, void *buf, size_t len, tarpc_blocking_aio_mode mode)
+                 int s, void *buf, tarpc_size_t len, tarpc_blocking_aio_mode mode)
 {
     return rpc_aio_read_blk_gen(rpcs, s, buf, len, mode, len);
 }
@@ -264,8 +264,8 @@ rpc_aio_read_blk(rcf_rpc_server *rpcs,
  *
  * @return Number of bytes received, otherwise -1 when error occured
  */
-extern ssize_t rpc_aio_write_blk(rcf_rpc_server *rpcs,
-                                 int s, const void *buf, size_t len, 
+extern tarpc_ssize_t rpc_aio_write_blk(rcf_rpc_server *rpcs,
+                                 int s, const void *buf, tarpc_size_t len,
                                  tarpc_blocking_aio_mode mode);
 
 /**
@@ -304,7 +304,7 @@ extern int rpc_nested_requests_test(rcf_rpc_server *rpcs,
  * @return size of data written
  */
 extern void rpc_write_at_offset_continuous(rcf_rpc_server *rpcs, int fd,
-                                           char* buf, size_t buflen,
+                                           char* buf, tarpc_size_t buflen,
                                            off_t offset, uint64_t time);
 
 #if 0
@@ -494,9 +494,9 @@ extern int rpc_get_socket_from_array(rcf_rpc_server *rpcs, rpc_ptr handle,
  * 
  * @return Received packets number or @c -1 in case of failure
  */
-extern int rpc_many_recv(rcf_rpc_server *rpcs, int sock, size_t length, 
+extern int rpc_many_recv(rcf_rpc_server *rpcs, int sock, tarpc_size_t length,
                          int num, int duration, void *last_packet,
-                         size_t last_packet_len, te_bool count_fails,
+                         tarpc_size_t last_packet_len, te_bool count_fails,
                          int *fails_num);
 
 
@@ -517,7 +517,7 @@ extern int rpc_many_recv(rcf_rpc_server *rpcs, int sock, size_t length,
  * @return Sent packets number or @c -1 in case of failure
  */
 extern int rpc_many_send_num_func(rcf_rpc_server *rpcs, int sock,
-                                  size_t length_min, size_t length_max,
+                                  tarpc_size_t length_min, tarpc_size_t length_max,
                                   int num, int duration,
                                   const char *func_name, te_bool check_len,
                                   te_bool count_fails, int *fails_num);
@@ -537,7 +537,7 @@ extern int rpc_many_send_num_func(rcf_rpc_server *rpcs, int sock,
  * @return Sent packets number or @c -1 in case of failure
  */
 static inline int
-rpc_many_send_num(rcf_rpc_server *rpcs, int sock, size_t length, int num,
+rpc_many_send_num(rcf_rpc_server *rpcs, int sock, tarpc_size_t length, int num,
                   int duration, te_bool check_len, te_bool count_fails,
                   int *fails_num)
 {
@@ -917,9 +917,9 @@ extern int rpc_onload_zc_unregister_buffers(rcf_rpc_server *rpcs,
  *
  * @return On succes, number of bytes actually sent, otherwise -1.
  */
-extern ssize_t rpc_onload_zc_send_msg_more(rcf_rpc_server *rpcs, int s,
-                                           rpc_ptr buf, size_t first_len,
-                                           size_t second_len,
+extern tarpc_ssize_t rpc_onload_zc_send_msg_more(rcf_rpc_server *rpcs, int s,
+                                           rpc_ptr buf, tarpc_size_t first_len,
+                                           tarpc_size_t second_len,
                                            te_bool first_zc,
                                            te_bool second_zc,
                                            te_bool use_reg_bufs,
@@ -1285,7 +1285,7 @@ rpc_simple_zc_recv_acc(rcf_rpc_server *rpcs, int s, struct rpc_msghdr *msg,
  *
  * @return Number of received bytes on success, @c -1 on failure.
  */
-extern ssize_t rpc_simple_hlrx_recv_zc(rcf_rpc_server *rpcs,
+extern tarpc_ssize_t rpc_simple_hlrx_recv_zc(rcf_rpc_server *rpcs,
                                        int s, struct rpc_msghdr *msg,
                                        rpc_send_recv_flags flags,
                                        te_bool os_inline);
@@ -1302,7 +1302,7 @@ extern ssize_t rpc_simple_hlrx_recv_zc(rcf_rpc_server *rpcs,
  *
  * @return Number of received bytes on success, @c -1 on failure.
  */
-extern ssize_t rpc_simple_hlrx_recv_copy(rcf_rpc_server *rpcs,
+extern tarpc_ssize_t rpc_simple_hlrx_recv_copy(rcf_rpc_server *rpcs,
                                          int s, struct rpc_msghdr *msg,
                                          rpc_send_recv_flags flags,
                                          te_bool os_inline);
@@ -1332,8 +1332,8 @@ extern int rpc_onload_set_recv_filter_capture(rcf_rpc_server *rpcs, int s,
  *
  * @return Number of bytes in packet on success, @c -1 on failure.
  */
-extern ssize_t rpc_sockts_recv_filtered_pkt(rcf_rpc_server *rpcs, int s,
-                                            char *buf, size_t len);
+extern tarpc_ssize_t rpc_sockts_recv_filtered_pkt(rcf_rpc_server *rpcs, int s,
+                                            char *buf, tarpc_size_t len);
 
 /**
  * Clear a queue of packets captured with UDP-RX filter.
@@ -1346,7 +1346,7 @@ extern int rpc_sockts_recv_filtered_pkts_clear(rcf_rpc_server *rpcs);
 
 extern int
 rpc_simple_set_recv_filter(rcf_rpc_server *rpcs, int s, const void *buf,
-                           size_t len, int flags);
+                           tarpc_size_t len, int flags);
 
 /** RPC definition of opaque pointer to the template metadata */
 typedef rpc_ptr rpc_onload_template_handle;
@@ -1364,8 +1364,8 @@ typedef enum rpc_onload_template_flags {
  */
 typedef struct rpc_onload_template_msg_update_iovec {
     void*     otmu_base;         /**< Pointer to new data */
-    size_t    otmu_len;          /**< Length of new data */
-    size_t    otmu_rlen;         /**< Actual length of update */
+    tarpc_size_t    otmu_len;          /**< Length of new data */
+    tarpc_size_t    otmu_rlen;         /**< Actual length of update */
     off_t     otmu_offset;       /**< Offset within template to update */
     uint32_t  otmu_flags;        /**< For future use. Must be set to 0 */
 } rpc_onload_template_msg_update_iovec;
@@ -1387,7 +1387,7 @@ typedef struct rpc_onload_template_msg_update_iovec {
  */
 extern int rpc_onload_msg_template_alloc_gen(rcf_rpc_server *rpcs, int fd,
                                          rpc_iovec* iov,
-                                         size_t iovcnt, size_t riovcnt,
+                                         tarpc_size_t iovcnt, tarpc_size_t riovcnt,
                                          rpc_onload_template_handle *handle,
                                          int flags);
 
@@ -1406,10 +1406,10 @@ extern int rpc_onload_msg_template_alloc_gen(rcf_rpc_server *rpcs, int fd,
  */
 static inline int
 rpc_onload_msg_template_alloc(rcf_rpc_server *rpcs, int fd, rpc_iovec* iov,
-                              size_t iovcnt, 
+                              tarpc_size_t iovcnt,
                               rpc_onload_template_handle *handle, int flags)
 {
-    size_t i;
+    tarpc_size_t i;
 
     for (i = 0; i < iovcnt; i++)
         iov[i].iov_rlen = iov[i].iov_len;
@@ -1436,7 +1436,7 @@ rpc_onload_msg_template_alloc(rcf_rpc_server *rpcs, int fd, rpc_iovec* iov,
 extern int rpc_onload_msg_template_update_gen(rcf_rpc_server *rpcs, int fd,
                               rpc_onload_template_handle handle,
                               rpc_onload_template_msg_update_iovec *updates,
-                              size_t iovcnt, size_t riovcnt,
+                              tarpc_size_t iovcnt, tarpc_size_t riovcnt,
                               int flags);
 
 /**
@@ -1456,9 +1456,9 @@ static inline int
 rpc_onload_msg_template_update(rcf_rpc_server *rpcs, int fd,
                               rpc_onload_template_handle handle,
                               rpc_onload_template_msg_update_iovec *updates,
-                              size_t iovcnt, int flags)
+                              tarpc_size_t iovcnt, int flags)
 {
-    size_t i;
+    tarpc_size_t i;
 
     for (i = 0; i < iovcnt; i++)
         updates[i].otmu_rlen = updates[i].otmu_len;
@@ -1494,7 +1494,7 @@ extern int rpc_onload_msg_template_abort(rcf_rpc_server *rpcs, int fd,
  * @return Status code
  */
 extern int rpc_template_send(rcf_rpc_server *rpcs, int fd, rpc_iovec* iov,
-                             size_t iovcnt, size_t riovcnt, int flags);
+                             tarpc_size_t iovcnt, tarpc_size_t riovcnt, int flags);
 
 /**
  * Repeatedly call functios popen()-fread()-pclose() in multiple threads.
@@ -1574,7 +1574,7 @@ rpc_onload_ordered_epoll_wait(rcf_rpc_server *rpcs, int epfd,
  * @param strbuf_len The string buffer length
  */
 extern void iov_h2rpc(struct tarpc_iovec* iov_arr, const rpc_iovec* iov,
-                      size_t iovcnt, char *strbuf, int strbuf_len);
+                      tarpc_size_t iovcnt, char *strbuf, int strbuf_len);
 
 /**
  * Send data from one or two sockets for a while, sometimes passing
@@ -1602,8 +1602,8 @@ extern void iov_h2rpc(struct tarpc_iovec* iov_arr, const rpc_iovec* iov,
 extern int rpc_send_msg_warm_flow(rcf_rpc_server *rpcs,
                                   const char *func_name,
                                   int fd1, int fd2,
-                                  size_t buf_size_min,
-                                  size_t buf_size_max,
+                                  tarpc_size_t buf_size_min,
+                                  tarpc_size_t buf_size_max,
                                   unsigned int time2run,
                                   uint64_t *sent1, uint64_t *sent2);
 
@@ -1630,8 +1630,8 @@ extern int rpc_send_msg_warm_flow(rcf_rpc_server *rpcs,
  * @return @c 0 on success, @c -1 on failure.
  */
 extern int rpc_many_send_cork(rcf_rpc_server *rpcs, int fd, int fd_aux,
-                              size_t size_min, size_t size_max,
-                              size_t send_num, size_t length,
+                              tarpc_size_t size_min, tarpc_size_t size_max,
+                              tarpc_size_t send_num, tarpc_size_t length,
                               int send_usleep, te_bool tcp_nodelay,
                               te_bool no_trigger);
 
@@ -1652,8 +1652,8 @@ extern int rpc_many_send_cork(rcf_rpc_server *rpcs, int fd, int fd_aux,
  * @return Length of data actually received on success, or @c -1 in case of
  *         failure.
  */
-extern ssize_t rpc_recv_timing(rcf_rpc_server *rpcs, int fd, int fd_aux,
-                               size_t length, uint64_t *duration);
+extern tarpc_ssize_t rpc_recv_timing(rcf_rpc_server *rpcs, int fd, int fd_aux,
+                               tarpc_size_t length, uint64_t *duration);
 
 /**
  * Call epoll_wait() in a loop until it returns non-zero (expect at most
@@ -1752,7 +1752,7 @@ extern int rpc_get_tcp_socket_state(rcf_rpc_server *rpcs,
  * @param rpcs          RPC server handle.
  * @param send_func     Transmitting function.
  * @param s             Socket descriptor.
- * @param len           Size of datagram (can be any within size_t type).
+ * @param len           Size of datagram (can be any within tarpc_size_t type).
  * @param flags         bitwise OR of zero or more of the following flags:
  *                      - RPC_MSG_OOB send out-of-band data if supported.
  *                      - RPC_MSG_DONTWAIT enable non-blocking operation.
@@ -1764,7 +1764,7 @@ extern int rpc_get_tcp_socket_state(rcf_rpc_server *rpcs,
  */
 extern int rpc_send_var_size(rcf_rpc_server *rpcs,
                              tarpc_send_function send_func,
-                             int s, size_t len,
+                             int s, tarpc_size_t len,
                              rpc_send_recv_flags flags,
                              const struct sockaddr *addr);
 
@@ -1778,7 +1778,7 @@ extern int rpc_send_var_size(rcf_rpc_server *rpcs,
  * @param rpcs          RPC server handle.
  * @param recv_func     Receiving function.
  * @param s             Socket descriptor.
- * @param len           Size of packet (can be any within size_t type).
+ * @param len           Size of packet (can be any within tarpc_size_t type).
  * @param flags         bitwise OR of zero or more of the following flags:
  *                      - RPC_MSG_OOB send out-of-band data if supported.
  *                      - RPC_MSG_DONTWAIT enable non-blocking operation.
@@ -1789,7 +1789,7 @@ extern int rpc_send_var_size(rcf_rpc_server *rpcs,
  */
 extern int rpc_recv_var_size(rcf_rpc_server *rpcs,
                              tarpc_recv_function recv_func,
-                             int s, size_t len,
+                             int s, tarpc_size_t len,
                              rpc_send_recv_flags flags);
 
 /**
@@ -1823,7 +1823,7 @@ extern rpc_ptr rpc_sockts_alloc_send_func_ctx(rcf_rpc_server *rpcs);
  */
 extern int rpc_sockts_send_func_ctx_init_zc_buf(rcf_rpc_server *rpcs,
                                                 rpc_ptr ctx, int fd,
-                                                size_t buf_size);
+                                                tarpc_size_t buf_size);
 
 /**
  * Clean ZC-related fields of sending function context set with

--- a/sockapi-ts/lib/sockapi-ts_rpc.h
+++ b/sockapi-ts/lib/sockapi-ts_rpc.h
@@ -96,7 +96,7 @@ extern int rpc_send_traffic(rcf_rpc_server *handle, int num, int *s,
  * @return   -1 in the case of failure or 0 on success
  */
 extern int rpc_many_send(rcf_rpc_server *handle, int sock, int flags,
-                         const int *vector, int nops, uint64_t *sent);
+                         const tarpc_size_t *vector, int nops, uint64_t *sent);
 
 /**
  * Execute a number of sendto() operation each after other with no delay.

--- a/sockapi-ts/meson.build
+++ b/sockapi-ts/meson.build
@@ -37,7 +37,6 @@ te_libs = [
     'logger_ten',
     'logic_expr',
     'ndn',
-    'tce',
     'tapi',
     'tapi_bpf',
     'tapi_env',

--- a/sockapi-ts/services/ftp_client.c
+++ b/sockapi-ts/services/ftp_client.c
@@ -460,7 +460,7 @@ main(int argc, char *argv[])
 
     CHECK_NOT_NULL(localfile = tapi_file_create(DATA_BULK, pattern, TRUE));
 
-    CHECK_RC(tapi_file_create_ta(pco_iut->ta, "/tmp/.netrc",
+    CHECK_RC(tapi_file_create_ta(pco_iut->ta, "/tmp/.netrc", "%s",
                                  "default login anonymous password foobar"));
     TMP_FILE(pco_iut->ta, "/tmp/.netrc");
 

--- a/sockapi-ts/sockopts/tcp_cork.c
+++ b/sockapi-ts/sockopts/tcp_cork.c
@@ -163,7 +163,7 @@ main(int argc, char *argv[])
     
     const struct if_nameindex *tst_if = NULL;
 
-    int                    send_length[2];
+    tarpc_size_t           send_length[2];
     uint64_t               total_sent;
     unsigned int           num;
     int                    ret;

--- a/sockapi-ts/sockopts/tcp_cork_aux.c
+++ b/sockapi-ts/sockopts/tcp_cork_aux.c
@@ -191,7 +191,7 @@ main(int argc, char *argv[])
     csap_handle_t              csap = CSAP_INVALID_HANDLE;
     unsigned int               received_packets_number = 0;
     unsigned int               i;
-    int                        send_length[MAX_PACKETS_NUM];
+    tarpc_size_t               send_length[MAX_PACKETS_NUM];
     uint64_t                   sent;
     te_bool                    remove_cork = FALSE;
     te_bool                    set_maxseg = FALSE;


### PR DESCRIPTION
The proposed set of patches makes it possible to build sapi-ts based on TE from https://github.com/oktetlabs/test-environment (commit 0ba28e7fa1a).

The following command line builds sapi-ts and all tests green (with Onload on commit fb14ba58c0):
```
./run.sh -q --cfg=nali --log-html=html --ool=onload --tester-req=\!BROKEN --tester-req=V5_SANITY
```