### PR TITLE
Tools

### DIFF
--- a/sockapi-ts/doc/sapi_tests.yml
+++ b/sockapi-ts/doc/sapi_tests.yml
@@ -3445,6 +3445,9 @@ groups:
     - test: ssh_client
       summary: Check OpenSSH connection establishing
 
+    - test: ssh_port_fwd_clnt
+      summary: SSH port forwarding on the client side
+
   - group: udp
     summary: UDP connections and round-trip
     objective: ''

--- a/sockapi-ts/doc/sapi_tests.yml
+++ b/sockapi-ts/doc/sapi_tests.yml
@@ -3438,6 +3438,13 @@ groups:
     - test: ts_msg_onepkt
       summary: Retrieve TCP RX timestamps with ONLOAD_MSG_ONEPKT flag
 
+  - group: tools
+    summary: Test suite to verify functioning of tools and utilities
+    objective: ''
+    tests:
+    - test: ssh_client
+      summary: Check OpenSSH connection establishing
+
   - group: udp
     summary: UDP connections and round-trip
     objective: ''

--- a/sockapi-ts/meson.build
+++ b/sockapi-ts/meson.build
@@ -149,6 +149,7 @@ packages = [
     'sockopts',
     'tcp',
     'timestamps',
+    'tools',
     'udp',
     'usecases',
 ]

--- a/sockapi-ts/package.dox
+++ b/sockapi-ts/package.dox
@@ -33,6 +33,7 @@
 - @ref sockopts
 - @ref tcp
 - @ref timestamps
+- @ref tools
 - @ref udp
 - @ref usecases
 

--- a/sockapi-ts/package.xml
+++ b/sockapi-ts/package.xml
@@ -1088,7 +1088,11 @@ Sending and receiving functions
         </run>    
         <run>
             <package name="tcp"/>
-        </run>   
+        </run>
+
+        <run>
+            <package name="tools"/>
+        </run>
 
         <run>
             <package name="multicast"/>

--- a/sockapi-ts/tools/lib/meson.build
+++ b/sockapi-ts/tools/lib/meson.build
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 OKTET Labs Ltd. All rights reserved.
+
+libtools_inc = include_directories('.')
+
+libtools_src = [
+    'tools_lib.c',
+]
+
+libtools = static_library('libtools', libtools_src,
+                          include_directories: [lib_dir, libtools_inc],
+                          dependencies: dep_tirpc)
+
+libtool_dep = declare_dependency(include_directories: libtools_inc,
+                                 link_with: libtools)

--- a/sockapi-ts/tools/lib/tools_lib.c
+++ b/sockapi-ts/tools/lib/tools_lib.c
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. */
+/** @file
+ * @brief Socket API Test Suite
+ *
+ * Implementations of common functions for tools package.
+ *
+ * @author Pavel Liulchak <Pavel.Liulchak@oktetlabs.ru>
+ */
+
+#include "te_str.h"
+#include "tapi_rpc_unistd.h"
+#include "tapi_rpc_misc.h"
+#include "tools_lib.h"
+#include "tapi_file.h"
+
+/* See description in tools_lib.h */
+te_errno
+tools_ssh_create_keys(rcf_rpc_server *rpcs,
+                      tools_ssh_key_data *key_data)
+{
+    return tapi_cfg_key_add(rpcs->ta, key_data->name,
+                            key_data->manager, key_data->type,
+                            key_data->size, TAPI_CFG_KEY_MODE_NEW);
+}
+
+/* See description in tools_lib.h */
+void
+tools_ssh_create_empty_sshd_config_file(rcf_rpc_server *rpcs)
+{
+    char *rpcs_ta_tmp_dir = NULL;
+    char *rpcs_ta_sshd_config_file = NULL;
+
+    CHECK_RC(cfg_get_instance_fmt(NULL, &rpcs_ta_tmp_dir,
+                                  "/agent:%s/tmp_dir:", rpcs->ta));
+
+    rpcs_ta_sshd_config_file = te_str_concat(rpcs_ta_tmp_dir, "sshd_config");
+    CHECK_RC(tapi_file_create_ta(rpcs->ta, rpcs_ta_sshd_config_file, "%s", ""));
+
+    free(rpcs_ta_sshd_config_file);
+    free(rpcs_ta_tmp_dir);
+}
+
+/* See description in tools_lib.h */
+void
+tools_ssh_prepare_client_file_paths_options(rcf_rpc_server *rpcs,
+                                            tapi_ssh_client_opt *client_opt)
+{
+    char *rpcs_ta_tmp_dir = NULL;
+
+    CHECK_RC(cfg_get_instance_fmt(NULL, &rpcs_ta_tmp_dir,
+                                  "/agent:%s/tmp_dir:", rpcs->ta));
+
+    client_opt->user_known_hosts_file = te_str_concat(rpcs_ta_tmp_dir, "known_hosts");
+    client_opt->identity_file =
+                        tapi_cfg_key_get_private_key_path(rpcs->ta,
+                                                          TOOLS_LIB_SSH_RSA_IDENTITY_KEY_NAME);
+
+    if (client_opt->identity_file == NULL)
+    {
+        TEST_FAIL("Cannot get identity key path for '%s' on %s",
+                  TOOLS_LIB_SSH_RSA_IDENTITY_KEY_NAME, rpcs->ta);
+    }
+
+    free(rpcs_ta_tmp_dir);
+}
+
+/* See description in tools_lib.h */
+void
+tools_ssh_free_client_file_paths_strings(tapi_ssh_client_opt *client_opt)
+{
+    free(client_opt->user_known_hosts_file);
+    free(client_opt->identity_file);
+}
+
+/* See description in tools_lib.h */
+void
+tools_ssh_prepare_server_file_paths_options(rcf_rpc_server *rpcs,
+                                            tapi_ssh_server_opt *server_opt)
+{
+    char *rpcs_ta_tmp_dir = NULL;
+
+    CHECK_RC(cfg_get_instance_fmt(NULL, &rpcs_ta_tmp_dir,
+                                  "/agent:%s/tmp_dir:", rpcs->ta));
+
+    server_opt->authorized_keys_file = te_str_concat(rpcs_ta_tmp_dir, "authorized_keys");
+    server_opt->pid_file = te_str_concat(rpcs_ta_tmp_dir, "sshd.pid");
+    server_opt->config_file = te_str_concat(rpcs_ta_tmp_dir, "sshd_config");
+    server_opt->host_key_file =
+                        tapi_cfg_key_get_private_key_path(rpcs->ta,
+                                                          TOOLS_LIB_SSH_RSA_HOSTKEY_NAME);
+
+    if (server_opt->host_key_file == NULL)
+    {
+        TEST_FAIL("Cannot get hostkey file path for '%s' on %s",
+                  TOOLS_LIB_SSH_RSA_IDENTITY_KEY_NAME, rpcs->ta);
+    }
+
+    free(rpcs_ta_tmp_dir);
+}
+
+/* See description in tools_lib.h */
+void
+tools_ssh_free_server_file_paths_strings(tapi_ssh_server_opt *server_opt)
+{
+    free(server_opt->authorized_keys_file);
+    free(server_opt->pid_file);
+    free(server_opt->config_file);
+    free(server_opt->host_key_file);
+}

--- a/sockapi-ts/tools/lib/tools_lib.h
+++ b/sockapi-ts/tools/lib/tools_lib.h
@@ -1,0 +1,146 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. */
+/** @file
+ * @brief Socket API Test Suite
+ *
+ * Common definitions for tools package.
+ *
+ * @author Pavel Liulchak <Pavel.Liulchak@oktetlabs.ru>
+ */
+
+#ifndef __TS_TOOLS_LIB_H__
+#define __TS_TOOLS_LIB_H__
+
+#include "sockapi-test.h"
+#include "tapi_ssh.h"
+#include "tapi_job.h"
+#include "tapi_job_factory_rpc.h"
+#include "tapi_cfg_key.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * User name to log in as on the remote machine.
+ */
+#define TOOLS_LIB_SSH_DEFAULT_USER_NAME "root"
+
+/**
+ * Identity key file filename.
+ */
+#define TOOLS_LIB_SSH_RSA_IDENTITY_KEY_NAME "rsa_identity"
+
+/**
+ * Hostkey file filename.
+ */
+#define TOOLS_LIB_SSH_RSA_HOSTKEY_NAME "rsa_hostkey"
+
+/** Enum representation of hosts involved in the testing */
+typedef enum {
+    TOOLS_LIB_SSH_IUT = 0,  /**< Use pco_iut */
+    TOOLS_LIB_SSH_TST1,     /**< Use pco_tst1 */
+    TOOLS_LIB_SSH_TST2,     /**< Use pco_tst2 */
+} tools_lib_ssh_host;
+
+/**
+ * List for TEST_GET_ENUM_PARAM() macro to obtain an argument
+ * of tools_lib_ssh_host type
+ */
+#define TOOLS_LIB_SSH_HOST \
+    {"iut", TOOLS_LIB_SSH_IUT},     \
+    {"tst1", TOOLS_LIB_SSH_TST1},   \
+    {"tst2", TOOLS_LIB_SSH_TST2}
+
+/**
+ * Macro for ssh key data structure initialization.
+ */
+#define TOOLS_SSH_RSA_KEY_DATA_INIT(_name) { \
+    .name = _name,                           \
+    .manager = TAPI_CFG_KEY_MANAGER_SSH,     \
+    .type = TAPI_CFG_KEY_TYPE_SSH_RSA,       \
+    .size = TAPI_CFG_KEY_SIZE_RECOMMENDED,   \
+}
+
+/** Data about key to create */
+typedef struct tools_ssh_key_data
+{
+    const char *name;
+    tapi_cfg_key_manager manager;
+    tapi_cfg_key_type type;
+    tapi_cfg_key_size size;
+} tools_ssh_key_data;
+
+/**
+ * Create public and private keys according to @p key_data.
+ *
+ * @param rpcs                  RPC server handle.
+ * @param key_data              Data about key to create.
+ *
+ * @return Status code.
+ */
+extern te_errno tools_ssh_create_keys(rcf_rpc_server *rpcs,
+                                      tools_ssh_key_data *key_data);
+
+/**
+ * Create empty sshd_config file.
+ *
+ * @note It is useful to create an empty custom configuration file
+ *       to prevent sshd from usage default one /etc/ssh/sshd_config
+ *       that may be a cause of errors related with deprecation options.
+ *
+ * @param rpcs                  RPC server handle.
+ */
+extern void tools_ssh_create_empty_sshd_config_file(rcf_rpc_server *rpcs);
+
+/**
+ * Prepare paths to files in the client options structure.
+ *
+ * @note Use #tools_ssh_free_client_file_paths_strings to free the
+ *       allocated strings that keep files paths
+ *
+ * @param rpcs                  RPC server handle.
+ * @param client_opt            Client command line options.
+ *
+ * @sa tools_ssh_free_client_file_paths_strings
+ */
+extern void tools_ssh_prepare_client_file_paths_options(rcf_rpc_server *rpcs,
+                                                        tapi_ssh_client_opt *client_opt);
+
+/**
+ * Free paths to files in the client options structure.
+ *
+ * @param client_opt            Client command line options.
+ *
+ * @sa tools_ssh_prepare_client_file_paths_options
+ */
+extern void tools_ssh_free_client_file_paths_strings(tapi_ssh_client_opt *client_opt);
+
+/**
+ * Prepare paths to files in the server options structure.
+ *
+ * @note Use #tools_ssh_free_server_file_paths_strings to free the
+ *       allocated strings that keep files paths
+ *
+ * @param rpcs                  RPC server handle.
+ * @param server_opt            Server command line options.
+ *
+ * @sa tools_ssh_free_server_file_paths_strings
+ */
+extern void tools_ssh_prepare_server_file_paths_options(rcf_rpc_server *rpcs,
+                                                        tapi_ssh_server_opt *server_opt);
+
+/**
+ * Free paths to files in the server options structure.
+ *
+ * @param server_opt            Server command line options.
+ *
+ * @sa tools_ssh_prepare_server_file_paths_options
+ */
+extern void tools_ssh_free_server_file_paths_strings(tapi_ssh_server_opt *server_opt);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __TS_TOOLS_LIB_H__ */

--- a/sockapi-ts/tools/meson.build
+++ b/sockapi-ts/tools/meson.build
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 OKTET Labs Ltd. All rights reserved.
+
+subdir('lib')
+
+tools_test_deps = test_deps
+tools_test_deps += libtool_dep
+
+tests = [
+    'prologue',
+    'ssh_client',
+]
+
+foreach test : tests
+    test_exe = test
+    test_c = test + '.c'
+    package_tests_c += [ test_c ]
+    executable(test_exe, test_c, install: true, install_dir: package_dir,
+               dependencies: tools_test_deps)
+endforeach
+
+tests_info_xml = custom_target(package_dir.underscorify() + 'tests-info-xml',
+                               install: true, install_dir: package_dir,
+                               input: package_tests_c,
+                               output: 'tests-info.xml', capture: true,
+                               command: [ te_tests_info_sh,
+                               meson.current_source_dir() ])
+
+install_data([ 'package.dox', 'package.xml' ], install_dir: package_dir)

--- a/sockapi-ts/tools/meson.build
+++ b/sockapi-ts/tools/meson.build
@@ -9,6 +9,7 @@ tools_test_deps += libtool_dep
 tests = [
     'prologue',
     'ssh_client',
+    'ssh_port_fwd_clnt',
 ]
 
 foreach test : tests

--- a/sockapi-ts/tools/package.dox
+++ b/sockapi-ts/tools/package.dox
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. */
+/**
+
+@defgroup tools Tools testing
+
+@ingroup sockapi
+@{
+
+Test suite to verify functioning of tools and utilities.
+
+@par Tests:
+
+-# @ref tools-prologue
+-# @ref tools-ssh_client
+
+@}tools
+
+*/

--- a/sockapi-ts/tools/package.dox
+++ b/sockapi-ts/tools/package.dox
@@ -13,6 +13,7 @@ Test suite to verify functioning of tools and utilities.
 
 -# @ref tools-prologue
 -# @ref tools-ssh_client
+-# @ref tools-ssh_port_fwd_clnt
 
 @}tools
 

--- a/sockapi-ts/tools/package.xml
+++ b/sockapi-ts/tools/package.xml
@@ -23,5 +23,36 @@
                <value>tst2</value>
             </arg>
         </run>
+
+        <run>
+            <script name="ssh_port_fwd_clnt"/>
+            <arg name="env">
+               <value ref="env.two_nets.iut_first"/>
+            </arg>
+            <arg name="tester" list="">
+               <value>tst2</value>
+               <value>tst1</value>
+               <value>tst1</value>
+               <value>tst2</value>
+               <value>tst1</value>
+               <value>tst2</value>
+            </arg>
+            <arg name="server" list="">
+               <value>tst2</value>
+               <value>tst1</value>
+               <value>iut</value>
+               <value>iut</value>
+               <value>tst2</value>
+               <value>tst1</value>
+            </arg>
+            <arg name="client" list="">
+               <value>iut</value>
+               <value>iut</value>
+               <value>tst1</value>
+               <value>tst2</value>
+               <value>tst1</value>
+               <value>tst2</value>
+            </arg>
+        </run>
     </session>
 </package>

--- a/sockapi-ts/tools/package.xml
+++ b/sockapi-ts/tools/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. -->
+<package version="1.0">
+
+    <description>Tools testing</description>
+
+    <author mailto="Pavel.Liulchak@oktetlabs.ru"/>
+
+    <session>
+        <prologue>
+            <script name="prologue"/>
+            <arg name="env" ref="env.iut_only"/>
+        </prologue>
+
+        <run>
+            <script name="ssh_client"/>
+            <arg name="env">
+               <value ref="env.two_nets.iut_first"/>
+            </arg>
+            <arg name="server">
+               <value>tst1</value>
+               <value>tst2</value>
+            </arg>
+        </run>
+    </session>
+</package>

--- a/sockapi-ts/tools/prologue.c
+++ b/sockapi-ts/tools/prologue.c
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. */
+/*
+ * Socket API Test Suite
+ * Tools testing
+ */
+
+/**
+ * @page tools-prologue Tools package prologue
+ *
+ * @objective Configure IUT host for tools tests.
+ *
+ * @param env   Testing environment:
+ *              - @ref arg_types_env_iut_only
+ *
+ * @par Scenario:
+ *
+ * @author Pavel Liulchak <Pavel.Liulchak@oktetlabs.ru>
+ */
+
+/** Logging subsystem entity name */
+#define TE_TEST_NAME    "tools/prologue"
+
+#include "sockapi-test.h"
+#include "onload.h"
+
+int
+main(int argc, char *argv[])
+{
+    rcf_rpc_server *pco_iut;
+
+    TEST_START;
+    TEST_GET_PCO(pco_iut);
+
+    TEST_STEP("Copy te_onload script to IUT.");
+    CHECK_RC(tapi_onload_copy_sapi_ts_script(pco_iut, PATH_TO_TE_ONLOAD));
+
+    TEST_SUCCESS;
+
+cleanup:
+    TEST_END;
+}

--- a/sockapi-ts/tools/ssh_client.c
+++ b/sockapi-ts/tools/ssh_client.c
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. */
+/*
+ * Socket API Test Suite
+ * Tools testing
+ */
+
+/**
+ * @page tools-ssh_client Check OpenSSH connection establishing
+ *
+ * @objective Check that SSH client can connect to the SSH server (sshd)
+ *            using `true` comand.
+ *
+ * @param env       Testing environment:
+ *                  - @ref arg_types_env_two_nets_iut_first
+ * @param server    PCO of ssh server (sshd):
+ *                  - @c tst1
+ *                  - @c tst2
+ *
+ * @par Scenario:
+ *
+ * @author Pavel Liulchak <Pavel.Liulchak@oktetlabs.ru>
+ */
+
+#define TE_TEST_NAME  "tools/ssh_client"
+
+#include "tapi_ssh.h"
+#include "sockapi-test.h"
+#include "tapi_job.h"
+#include "tapi_job_factory_rpc.h"
+#include "onload.h"
+#include "tools_lib.h"
+
+/**
+ * SSH request command
+ */
+#define SSH_CLIENT_COMMAND "true"
+
+int
+main(int argc, char *argv[])
+{
+    tapi_job_factory_t*    iut_ssh_factory = NULL;
+    tapi_job_factory_t*    tst_sshd_factory = NULL;
+
+    tapi_ssh_client_opt    iut_ssh_opt =
+                                tapi_ssh_client_opt_default_opt;
+    tapi_ssh_server_opt    tst_sshd_opt =
+                                tapi_ssh_server_opt_default_opt;
+
+    tapi_ssh_t*            iut_ssh = NULL;
+    tapi_ssh_t*            tst_sshd = NULL;
+
+    tools_ssh_key_data iut_key =
+        TOOLS_SSH_RSA_KEY_DATA_INIT(TOOLS_LIB_SSH_RSA_IDENTITY_KEY_NAME);
+    tools_ssh_key_data tst_key =
+        TOOLS_SSH_RSA_KEY_DATA_INIT(TOOLS_LIB_SSH_RSA_HOSTKEY_NAME);
+
+    tapi_job_wrapper_t *wrap = NULL;
+
+    rcf_rpc_server        *pco_iut = NULL;
+    rcf_rpc_server        *pco_tst1 = NULL;
+    rcf_rpc_server        *pco_tst2 = NULL;
+    rcf_rpc_server        *pco_tst = NULL;
+
+    const struct sockaddr *tst1_addr;
+    const struct sockaddr *tst2_addr;
+    const struct sockaddr *tst_addr;
+
+    tools_lib_ssh_host server;
+
+    TEST_START;
+    TEST_GET_PCO(pco_iut);
+    TEST_GET_PCO(pco_tst1);
+    TEST_GET_PCO(pco_tst2);
+    TEST_GET_ADDR(pco_tst1, tst1_addr);
+    TEST_GET_ADDR(pco_tst2, tst2_addr);
+
+    TEST_GET_ENUM_PARAM(server, TOOLS_LIB_SSH_HOST);
+
+    switch(server)
+    {
+        case TOOLS_LIB_SSH_TST1:
+            pco_tst = pco_tst1;
+            tst_addr = tst1_addr;
+            break;
+
+        case TOOLS_LIB_SSH_TST2:
+            pco_tst = pco_tst2;
+            tst_addr = tst2_addr;
+            break;
+
+        default:
+            TEST_FAIL("Unknown server parameter");
+    }
+
+    TEST_STEP("Create public and private ssh keys both on server and client side.");
+    CHECK_RC(tools_ssh_create_keys(pco_iut, &iut_key));
+    CHECK_RC(tools_ssh_create_keys(pco_tst, &tst_key));
+
+    TEST_STEP("Copy client public ssh key to the server authorized_keys file.");
+    CHECK_RC(tapi_cfg_key_append_public(pco_iut->ta, iut_key.name,
+                                        pco_tst->ta, "authorized_keys"));
+
+    TEST_STEP("Create empty sshd_config file.");
+    tools_ssh_create_empty_sshd_config_file(pco_tst);
+
+    TEST_STEP("Prepare ssh server (detached sshd) options.");
+    tst_sshd_opt.port = ntohs(te_sockaddr_get_port(tst_addr));
+    tools_ssh_prepare_server_file_paths_options(pco_tst, &tst_sshd_opt);
+
+    TEST_STEP("Create ssh server (sshd) job.");
+    CHECK_RC(tapi_job_factory_rpc_create(pco_tst, &tst_sshd_factory));
+    CHECK_RC(tapi_ssh_create_server(tst_sshd_factory, &tst_sshd_opt, &tst_sshd));
+
+    TEST_STEP("Start ssh server (sshd).");
+    CHECK_RC(tapi_ssh_start_app(tst_sshd));
+
+    TEST_STEP("Wait to allow ssh server (sshd) launch.");
+    TAPI_WAIT_NETWORK;
+
+    TEST_STEP("Prepare ssh client options.");
+    iut_ssh_opt.login_name = TOOLS_LIB_SSH_DEFAULT_USER_NAME;
+    iut_ssh_opt.port = tst_sshd_opt.port;
+    iut_ssh_opt.destination = te_ip2str(tst_addr);
+    iut_ssh_opt.command = SSH_CLIENT_COMMAND;
+    tools_ssh_prepare_client_file_paths_options(pco_iut, &iut_ssh_opt);
+
+    TEST_STEP("Create ssh client job.");
+    CHECK_RC(tapi_job_factory_rpc_create(pco_iut, &iut_ssh_factory));
+    CHECK_RC(tapi_ssh_create_client(iut_ssh_factory, &iut_ssh_opt, &iut_ssh));
+
+    if (tapi_onload_lib_exists(pco_iut->ta))
+    {
+        const char *tool = PATH_TO_TE_ONLOAD;
+        const char *tool_argv[2] = {
+            PATH_TO_TE_ONLOAD,
+            NULL
+        };
+        CHECK_RC(tapi_ssh_client_wrapper_add(iut_ssh, tool, tool_argv,
+                                            TAPI_JOB_WRAPPER_PRIORITY_DEFAULT,
+                                            &wrap));
+    }
+
+    TEST_STEP("Start ssh client.");
+    CHECK_RC(tapi_ssh_start_app(iut_ssh));
+
+    TEST_STEP("Wait for completion ssh client request.");
+    CHECK_RC(tapi_ssh_wait_app(iut_ssh, TAPI_SSH_APP_WAIT_TIME_MS));
+
+    TEST_SUCCESS;
+
+cleanup:
+    CLEANUP_CHECK_RC(tapi_ssh_kill_app(tst_sshd, SIGTERM));
+
+    CLEANUP_CHECK_RC(tapi_ssh_destroy_app(iut_ssh));
+    CLEANUP_CHECK_RC(tapi_ssh_destroy_app(tst_sshd));
+
+    tools_ssh_free_client_file_paths_strings(&iut_ssh_opt);
+    tools_ssh_free_server_file_paths_strings(&tst_sshd_opt);
+
+    free(wrap);
+    free(iut_ssh_opt.destination);
+
+    CLEANUP_CHECK_RC(tapi_cfg_key_del(pco_iut->ta, iut_key.name));
+    CLEANUP_CHECK_RC(tapi_cfg_key_del(pco_tst->ta, tst_key.name));
+
+    TEST_END;
+}

--- a/sockapi-ts/tools/ssh_port_fwd_clnt.c
+++ b/sockapi-ts/tools/ssh_port_fwd_clnt.c
@@ -1,0 +1,488 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. */
+/*
+ * Socket API Test Suite
+ * Tools testing
+ */
+
+/**
+ * @page tools-ssh_port_fwd_clnt SSH port forwarding on the client side
+ *
+ * @objective Check that SSH server performs TCP forwarding properly.
+ *
+ * @param env       Testing environment:
+ *                  - @ref arg_types_env_two_nets_iut_first
+ * @param tester    Tester end of the client:
+ *                  - @c tst1
+ *                  - @c tst2
+ * @param server    PCO of TCP server:
+ *                  - @c iut
+ *                  - @c tst1
+ *                  - @c tst2
+ * @param client    PCO of TCP client:
+ *                  - @c iut
+ *                  - @c tst1
+ *                  - @c tst2
+ *
+ * @par Scenario:
+ *
+ * @author Pavel Liulchak <Pavel.Liulchak@oktetlabs.ru>
+ */
+
+#define TE_TEST_NAME  "tools/ssh_port_fwd_clnt"
+
+#include "tapi_ssh.h"
+#include "sockapi-test.h"
+#include "tapi_job_factory_rpc.h"
+#include "onload.h"
+#include "tools_lib.h"
+
+/**
+ * Max length of string representation of connection to be forwarded
+ * @note an example of representation: [bind_address:]port:host:hostport
+ */
+#define SSH_PORT_FWD_CLNT_MAX_FORWARDING_BUF_LENGTH 50
+
+
+static rcf_rpc_server *pco_iut = NULL;
+static rcf_rpc_server *pco_tst1 = NULL;
+static rcf_rpc_server *pco_tst2 = NULL;
+
+static const struct sockaddr  *iut_addr1 = NULL;
+static const struct sockaddr  *iut_addr2 = NULL;
+static const struct sockaddr  *tst1_addr = NULL;
+static const struct sockaddr  *tst2_addr = NULL;
+
+/** Data corresponding to one secure tunnel */
+typedef struct ssh_port_fwd_clnt_tunnel {
+    rcf_rpc_server  *tst;                    /**< Tester end of the client */
+    rcf_rpc_server  *srv;                    /**< TCP server PCO */
+    rcf_rpc_server  *clnt;                   /**< TCP client PCO */
+
+    const struct sockaddr *tst_addr;         /**< Address corresponding to tester */
+    struct sockaddr_storage srv_addr;        /**< TCP server address */
+    struct sockaddr_storage proxy_addr;      /**< Proxy address */
+
+    te_bool remote_port_forwarding;          /**< Port forwarding type */
+
+    tapi_job_factory_t     *factory;         /**< Tunnel job factory */
+    tapi_ssh_t             *tunnel;          /**< Tunnel app handle */
+    tapi_job_wrapper_t     *wrap;            /**< Tunnel wrapper instance handle */
+    uint16_t port;                           /**< Port on which remote host sshd is run */
+
+    int s_srv;                               /**< Socket for listening on the TCP */
+    int s_clnt[2];                           /**< Client sockets */
+    int s_acc[2];                            /**< Socket for accepted connections */
+} ssh_port_fwd_clnt_tunnel_t;
+
+/**
+ * Context initializer for tunnel data.
+ *
+ * @param tdata        tunnel data context.
+ *
+ */
+static void
+init_tunnel_data(ssh_port_fwd_clnt_tunnel_t *tdata)
+{
+    tdata->tst = NULL;
+    tdata->srv = NULL;
+    tdata->clnt = NULL;
+
+    tdata->tst_addr = NULL;
+
+    tdata->factory = NULL;
+    tdata->tunnel = NULL;
+    tdata->wrap = NULL;
+
+    tdata->s_srv = tdata->s_clnt[0] =
+    tdata->s_clnt[1] = tdata->s_acc[0] =
+    tdata->s_acc[1] = -1;
+}
+
+/**
+ * Get RPC server via related host parameter.
+ *
+ * @param host        host parameter.
+ *
+ * @return RPC server.
+ */
+static rcf_rpc_server*
+retrieve_pco_via_host_param(tools_lib_ssh_host host)
+{
+    switch(host)
+    {
+        case TOOLS_LIB_SSH_IUT:
+            return pco_iut;
+
+        case TOOLS_LIB_SSH_TST1:
+            return pco_tst1;
+
+        case TOOLS_LIB_SSH_TST2:
+            return pco_tst2;
+
+        default:
+            return NULL;
+    }
+}
+
+/**
+ * Get TST RPC server address.
+ *
+ * @param host        host parameter related with a TST side.
+ *
+ * @return TST server address.
+ */
+static const struct sockaddr*
+retrieve_tst_sockaddr_via_host_param(tools_lib_ssh_host host)
+{
+    switch(host)
+    {
+        case TOOLS_LIB_SSH_TST1:
+            return tst1_addr;
+
+        case TOOLS_LIB_SSH_TST2:
+            return tst2_addr;
+
+        default:
+            return NULL;
+    }
+}
+
+/**
+ * Get IUT RPC server address within net shared with TST side.
+ *
+ * @param tst_host        host parameter related with a TST side.
+ *
+ * @note It is assumed that host with @p pco_tst2 is connected with
+ * @p pco_iut via different network segment than one connecting
+ * @p pco_tst1 and @p pco_iut.
+ *
+ * @return IUT server address.
+ */
+static const struct sockaddr*
+retrieve_iut_sockaddr_via_tst_host_param(tools_lib_ssh_host tst_host)
+{
+    switch(tst_host)
+    {
+        case TOOLS_LIB_SSH_TST1:
+            return iut_addr1;
+
+        case TOOLS_LIB_SSH_TST2:
+            return iut_addr2;
+
+        default:
+            return NULL;
+    }
+}
+
+/**
+ * Check by host parameter if host is IUT.
+ *
+ * @param host        host parameter.
+ *
+ * @return @c TRUE if host is IUT.
+ */
+static inline te_bool
+host_is_iut(tools_lib_ssh_host host)
+{
+    switch(host)
+    {
+        case TOOLS_LIB_SSH_IUT:
+            return TRUE;
+        default:
+            return FALSE;
+    }
+}
+
+/**
+ * Get RPC server address within net shared with TST side.
+ *
+ * @param host_param        host parameter.
+ * @param tst_host_param    host parameter related with a TST side.
+ *
+ * @return RPC server address.
+ */
+static const struct sockaddr*
+retrieve_sockaddr_via_host_params(tools_lib_ssh_host host_param,
+                                  tools_lib_ssh_host tst_host_param)
+{
+    const struct sockaddr *addr;
+
+    if (host_is_iut(host_param))
+        addr = retrieve_iut_sockaddr_via_tst_host_param(tst_host_param);
+    else
+        addr = retrieve_tst_sockaddr_via_host_param(host_param);
+
+    CHECK_NOT_NULL(addr);
+
+    return addr;
+}
+
+/**
+ * Fill data about the tunnel.
+ *
+ * @param tdata         The tunnel data to set.
+ * @param tester        Param related with tester end PCO.
+ * @param server        Param related with TCP server PCO.
+ * @param client        Param related with TCP client PCO.
+ *
+ */
+static void
+prepare_tunnel_data(ssh_port_fwd_clnt_tunnel_t *tdata,
+                    tools_lib_ssh_host tester,
+                    tools_lib_ssh_host server,
+                    tools_lib_ssh_host client)
+{
+    CHECK_NOT_NULL(tdata->tst = retrieve_pco_via_host_param(tester));
+    CHECK_NOT_NULL(tdata->tst_addr = retrieve_tst_sockaddr_via_host_param(tester));
+
+    CHECK_NOT_NULL(tdata->srv = retrieve_pco_via_host_param(server));
+    CHECK_RC(tapi_sockaddr_clone(tdata->srv,
+                                 retrieve_sockaddr_via_host_params(server, tester),
+                                 &tdata->srv_addr));
+
+    CHECK_NOT_NULL(tdata->clnt = retrieve_pco_via_host_param(client));
+    CHECK_RC(tapi_sockaddr_clone(tdata->clnt,
+                                 retrieve_sockaddr_via_host_params(client, tester),
+                                 &tdata->proxy_addr));
+
+    tdata->remote_port_forwarding = !host_is_iut(client);
+    tdata->port = ntohs(te_sockaddr_get_port(tdata->tst_addr));
+}
+
+/**
+ * Create the SSH tunnel for TCP forwarding.
+ *
+ * @note In case of local and remote port forwarding the comandlines
+ *       look like:
+ *       ssh -g -N -L proxy_port:srv_ip:srv_port -p @p tdata->port tst_ip
+ *       ssh -g -N -R proxy_port:srv_ip:srv_port -p @p tdata->port tst_ip
+ *       where
+ *       - proxy_port is a @p client port from which connections forward.
+ *       - srv_ip is address of @p server.
+ *       - srv_port is a @p server port to which connections forward.
+ *       - @p tdata->port is a @p tester port on which sshd is run.
+ *       - tst_ip is address of @p tester.
+ *
+ * @param tdata     Data about the tunnel to create.
+ *
+ */
+static void
+create_tunnel(ssh_port_fwd_clnt_tunnel_t *tdata)
+{
+    char forwarding_buf[SSH_PORT_FWD_CLNT_MAX_FORWARDING_BUF_LENGTH];
+    uint16_t proxy_port;
+    uint16_t srv_port;
+    const char *srv_ip = NULL;
+    char *tst_ip = NULL;
+    tapi_ssh_client_opt tunnel_opt = tapi_ssh_client_opt_default_opt;
+
+    proxy_port = ntohs(te_sockaddr_get_port(SA(&tdata->proxy_addr)));
+    srv_port = ntohs(te_sockaddr_get_port(SA(&tdata->srv_addr)));
+
+    srv_ip = te_sockaddr_get_ipstr(SA(&tdata->srv_addr));
+
+    if (srv_ip == NULL)
+        TEST_FAIL("Can't detect server host to forward to");
+
+    te_snprintf(forwarding_buf, sizeof(forwarding_buf),
+                "%d:%s:%d", proxy_port, srv_ip, srv_port);
+
+    tst_ip = te_ip2str(tdata->tst_addr);
+
+    RING("Prepare the tunnel options");
+    tunnel_opt.gateway_ports = TRUE;
+    tunnel_opt.forbid_remote_commands_execution = TRUE;
+
+    if (tdata->remote_port_forwarding)
+        tunnel_opt.remote_port_forwarding = forwarding_buf;
+    else
+        tunnel_opt.local_port_forwarding = forwarding_buf;
+
+    tunnel_opt.login_name = TOOLS_LIB_SSH_DEFAULT_USER_NAME;
+    tunnel_opt.port = tdata->port;
+    tunnel_opt.destination = tst_ip;
+
+    tools_ssh_prepare_client_file_paths_options(pco_iut, &tunnel_opt);
+
+    RING("Create the tunnel job");
+    CHECK_RC(tapi_job_factory_rpc_create(pco_iut, &(tdata->factory)));
+    CHECK_RC(tapi_ssh_create_client(tdata->factory, &(tunnel_opt), &(tdata->tunnel)));
+
+    if (tapi_onload_lib_exists(pco_iut->ta))
+    {
+        const char *tool = PATH_TO_TE_ONLOAD;
+        const char *tool_argv[2] = {
+            PATH_TO_TE_ONLOAD,
+            NULL
+        };
+        CHECK_RC(tapi_ssh_client_wrapper_add(tdata->tunnel, tool, tool_argv,
+                                             TAPI_JOB_WRAPPER_PRIORITY_DEFAULT,
+                                             &tdata->wrap));
+    }
+
+    RING("Start the tunnel");
+    CHECK_RC(tapi_ssh_start_app(tdata->tunnel));
+
+    RING("Wait the tunnel start");
+    TAPI_WAIT_NETWORK;
+
+    free(tst_ip);
+
+    tools_ssh_free_client_file_paths_strings(&tunnel_opt);
+}
+
+/**
+ * Create TCP connections via the SSH tunnel.
+ *
+ * @param tdata     Data about the tunnel through which connections
+ *                  to be created.
+ *
+ */
+static void
+create_connections(ssh_port_fwd_clnt_tunnel_t *tdata)
+{
+
+    if (tdata->remote_port_forwarding)
+        te_sockaddr_set_loopback(SA(&tdata->proxy_addr));
+
+    tdata->s_srv = rpc_create_and_bind_socket(tdata->srv, RPC_SOCK_STREAM,
+                                              RPC_PROTO_DEF, FALSE, FALSE,
+                                              SA(&tdata->srv_addr));
+    rpc_listen(tdata->srv, tdata->s_srv, 2);
+
+    tdata->s_clnt[0] = rpc_socket(tdata->tst, RPC_AF_INET,
+                                  RPC_SOCK_STREAM, RPC_PROTO_DEF);
+    tdata->s_clnt[1] = rpc_socket(tdata->clnt, RPC_AF_INET,
+                                  RPC_SOCK_STREAM, RPC_PROTO_DEF);
+
+    rpc_connect(tdata->tst, tdata->s_clnt[0], SA(&tdata->proxy_addr));
+    tdata->s_acc[0] = rpc_accept(tdata->srv, tdata->s_srv,
+                                 NULL, NULL);
+
+    rpc_connect(tdata->clnt, tdata->s_clnt[1], SA(&tdata->proxy_addr));
+    tdata->s_acc[1] = rpc_accept(tdata->srv, tdata->s_srv,
+                                 NULL, NULL);
+}
+
+/**
+ * Send/receive data via socket pair over SSH tunnel.
+ *
+ * @param tdata     Data about the tunnel through which connection
+ *                  to be checked.
+ */
+static void
+check_connections(ssh_port_fwd_clnt_tunnel_t *tdata)
+{
+    sockts_test_connection(tdata->tst, tdata->s_clnt[0],
+                           tdata->srv, tdata->s_acc[0]);
+
+    sockts_test_connection(tdata->srv, tdata->s_acc[0],
+                           tdata->tst, tdata->s_clnt[0]);
+
+    sockts_test_connection(tdata->clnt, tdata->s_clnt[1],
+                           tdata->srv, tdata->s_acc[1]);
+
+    sockts_test_connection(tdata->srv, tdata->s_acc[1],
+                           tdata->clnt, tdata->s_clnt[1]);
+}
+
+int
+main(int argc, char *argv[])
+{
+    rcf_rpc_server *pco_tst = NULL;
+    const struct sockaddr  *tst_addr = NULL;
+
+    tapi_job_factory_t*         tst_sshd_factory = NULL;
+    tapi_ssh_server_opt         tst_sshd_opt = tapi_ssh_server_opt_default_opt;
+    tapi_ssh_t*                 tst_sshd;
+
+    tools_ssh_key_data iut_key =
+        TOOLS_SSH_RSA_KEY_DATA_INIT(TOOLS_LIB_SSH_RSA_IDENTITY_KEY_NAME);
+    tools_ssh_key_data tst_key =
+        TOOLS_SSH_RSA_KEY_DATA_INIT(TOOLS_LIB_SSH_RSA_HOSTKEY_NAME);
+
+    ssh_port_fwd_clnt_tunnel_t tdata;
+
+    tools_lib_ssh_host tester;
+    tools_lib_ssh_host server;
+    tools_lib_ssh_host client;
+
+    init_tunnel_data(&tdata);
+
+    TEST_START;
+    TEST_GET_PCO(pco_iut);
+    TEST_GET_PCO(pco_tst1);
+    TEST_GET_PCO(pco_tst2);
+    TEST_GET_ADDR(pco_iut, iut_addr1);
+    TEST_GET_ADDR(pco_iut, iut_addr2);
+    TEST_GET_ADDR(pco_tst1, tst1_addr);
+    TEST_GET_ADDR(pco_tst2, tst2_addr);
+
+    TEST_GET_ENUM_PARAM(tester, TOOLS_LIB_SSH_HOST);
+    TEST_GET_ENUM_PARAM(server, TOOLS_LIB_SSH_HOST);
+    TEST_GET_ENUM_PARAM(client, TOOLS_LIB_SSH_HOST);
+
+    CHECK_NOT_NULL(pco_tst = retrieve_pco_via_host_param(tester));
+    CHECK_NOT_NULL(tst_addr = retrieve_tst_sockaddr_via_host_param(tester));
+
+    TEST_STEP("Create public and private ssh keys both on server and client side.");
+    CHECK_RC(tools_ssh_create_keys(pco_iut, &iut_key));
+    CHECK_RC(tools_ssh_create_keys(pco_tst, &tst_key));
+
+    TEST_STEP("Copy client public ssh key to the server authorized_keys file.");
+    CHECK_RC(tapi_cfg_key_append_public(pco_iut->ta, iut_key.name,
+                                        pco_tst->ta, "authorized_keys"));
+
+    TEST_STEP("Create empty sshd_config file.");
+    tools_ssh_create_empty_sshd_config_file(pco_tst);
+
+    TEST_STEP("Prepare tunnel data.");
+    prepare_tunnel_data(&tdata, tester, server, client);
+
+    TEST_STEP("Prepare ssh server (detached sshd) options.");
+    tst_sshd_opt.port = ntohs(te_sockaddr_get_port(tst_addr));
+    tools_ssh_prepare_server_file_paths_options(pco_tst, &tst_sshd_opt);
+
+    TEST_STEP("Create ssh server (sshd) job.");
+    CHECK_RC(tapi_job_factory_rpc_create(pco_tst, &tst_sshd_factory));
+    CHECK_RC(tapi_ssh_create_server(tst_sshd_factory, &tst_sshd_opt, &tst_sshd));
+
+    TEST_STEP("Start ssh server (sshd).");
+    CHECK_RC(tapi_ssh_start_app(tst_sshd));
+
+    TEST_STEP("Wait to allow ssh server (sshd) launch.");
+    TAPI_WAIT_NETWORK;
+
+    TEST_STEP("Create the tunnel.");
+    create_tunnel(&tdata);
+
+    TEST_STEP("Create connections through the tunnel.");
+    create_connections(&tdata);
+
+    TEST_STEP("Check connections through the tunnel.");
+    check_connections(&tdata);
+
+    TEST_SUCCESS;
+
+cleanup:
+    CLEANUP_CHECK_RC(tapi_ssh_kill_app(tst_sshd, SIGTERM));
+    CLEANUP_CHECK_RC(tapi_ssh_destroy_app(tst_sshd));
+
+    CLEANUP_RPC_CLOSE(tdata.srv, tdata.s_srv);
+    CLEANUP_RPC_CLOSE(tdata.srv, tdata.s_acc[0]);
+    CLEANUP_RPC_CLOSE(tdata.srv, tdata.s_acc[1]);
+    CLEANUP_RPC_CLOSE(tdata.tst, tdata.s_clnt[0]);
+    CLEANUP_RPC_CLOSE(tdata.clnt, tdata.s_clnt[1]);
+
+    CLEANUP_CHECK_RC(tapi_ssh_kill_app(tdata.tunnel, SIGTERM));
+    CLEANUP_CHECK_RC(tapi_ssh_destroy_app(tdata.tunnel));
+    free(tdata.wrap);
+
+    tools_ssh_free_server_file_paths_strings(&tst_sshd_opt);
+
+    CLEANUP_CHECK_RC(tapi_cfg_key_del(pco_iut->ta, iut_key.name));
+    CLEANUP_CHECK_RC(tapi_cfg_key_del(pco_tst->ta, tst_key.name));
+
+    TEST_END;
+}

--- a/trc/trc-sockapi-ts-tools.xml
+++ b/trc/trc-sockapi-ts-tools.xml
@@ -25,5 +25,15 @@
         <notes/>
       </iter>
     </test>
+    <test name="ssh_port_fwd_clnt" type="script">
+    <objective>Check that SSH server performs TCP forwarding properly</objective>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="tester"/>
+        <arg name="server"/>
+        <arg name="client"/>
+        <notes/>
+      </iter>
+    </test>
   </iter>
 </test>

--- a/trc/trc-sockapi-ts-tools.xml
+++ b/trc/trc-sockapi-ts-tools.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (C) 2022 OKTET Labs Ltd. All rights reserved. -->
+<test name="tools" type="package">
+  <objective>Necessary tools testing</objective>
+  <notes/>
+  <iter result="PASSED">
+    <notes/>
+    <test name="prologue" type="script">
+      <objective/>
+      <notes/>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <notes/>
+      </iter>
+    </test>
+    <test name="ssh_client" type="script">
+    <objective>
+        Check that SSH client can connect to the SSH server (sshd)
+        using `true` comand.
+    </objective>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="server"/>
+        <notes/>
+      </iter>
+    </test>
+  </iter>
+</test>

--- a/trc/trc-sockapi-ts.xml
+++ b/trc/trc-sockapi-ts.xml
@@ -111,6 +111,9 @@
       <xi:include href="trc-sockapi-ts-checksum.xml" parse="xml"
                   xmlns:xi="http://www.w3.org/2003/XInclude"/>
 
+      <xi:include href="trc-sockapi-ts-tools.xml" parse="xml"
+                  xmlns:xi="http://www.w3.org/2003/XInclude"/>
+
     </iter>
   </test>
 </trc_db>


### PR DESCRIPTION
The patch series adds new `tools` package with new ssh tests that `work`.
- ssh_client: Check that SSH client can connect to the SSH server (sshd) using `true` comand.
- ssh_port_fwd_clnt: Check that SSH server performs TCP forwarding properly.

Test runs have been performed on the revisions below:
Onload: `fb14ba58c05beede7bb6b3c451cddc2e6318f669`
TE: `ed5e9b0c48263d13c7c54b97d7290696b32b3267`

Tested both on pure linux and native onload using cmds below:
```
./run.sh -q --cfg=$host --tester-run=sockapi-ts/tools --ool=onload

./run.sh -q --cfg=$host --tester-run=sockapi-ts/tools

```
The tests have passed successfully in both cases.