### PR TITLE
scripts: allow to use separate file with hosts parameters

### DIFF
--- a/scripts/gen_onload_part.py
+++ b/scripts/gen_onload_part.py
@@ -263,14 +263,15 @@ def fix_testing_parms(host, ools, reqs, sl, slice_name,
 
 
 def gen_testing_part(rand, part_id, host, branch=None, parts_num_only=False,
-                     name_spec=False, af_xdp_strict=False):
-    if yamale_invalid(join(dirname(abspath(__file__)),
-                           "gen_onload_part.yaml")):
+                     name_spec=False, af_xdp_strict=False, params_file=None):
+    if params_file is None:
+        params_file = join(dirname(abspath(__file__)), "gen_onload_part.yaml")
+
+    if yamale_invalid(params_file, schema="gen_onload_part_schema.yaml"):
         print("Invalid configuration file!")
         exit()
 
-    with open(join(dirname(abspath(__file__)), "gen_onload_part.yaml"),
-              "r", encoding="utf-8") as cfg_file:
+    with open(params_file, "r", encoding="utf-8") as cfg_file:
         test_parts = load_yaml(cfg_file)
 
     parts = test_parts["parts"]
@@ -347,10 +348,13 @@ if __name__ == "__main__":
                         action="store_true")
     parser.add_argument("-x", help="Use af_xdp for testing",
                         action="store_true")
+    parser.add_argument("-u", "--use-params-file", dest="use_params_file",
+                        help="Use the specified file instead of gen_onload_part.yaml")
     args = parser.parse_args()
 
     gen_parts = gen_testing_part(args.rand_num, args.part, args.iut_host,
-                                 args.branch, False, args.n, args.x)
+                                 args.branch, False, args.n, args.x,
+                                 params_file=args.use_params_file)
     output = ""
 
     for p in gen_parts:


### PR DESCRIPTION
The parameters of the tested hosts depend on the specific site of use, and it would be better to save them and manage them in some internal storage

OL-Redmine-Id: 12239
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

Checked with both cases:
```shell
# default behaviour (used the default gen_onload_part.yaml file):
./gen_onload_part.py 1 1 <host-name>

# new behaviour (used the <path/to/separate/file.yml> file):
./gen_onload_part.py 1 1 <host-name> --use-params-file=<path/to/separate/file.yml>
```