### PR TITLE
scripts: use the absolute path for the yaml schema file

### DIFF
--- a/scripts/gen_onload_part.py
+++ b/scripts/gen_onload_part.py
@@ -267,7 +267,9 @@ def gen_testing_part(rand, part_id, host, branch=None, parts_num_only=False,
     if params_file is None:
         params_file = join(dirname(abspath(__file__)), "gen_onload_part.yaml")
 
-    if yamale_invalid(params_file, schema="gen_onload_part_schema.yaml"):
+    params_file_schema = join(dirname(abspath(__file__)),
+                              "gen_onload_part_schema.yaml")
+    if yamale_invalid(params_file, schema=params_file_schema):
         print("Invalid configuration file!")
         exit()
 


### PR DESCRIPTION
Otherwise, the script will only work if the schema file exists in the current directory.

Fixes: 7fdb9bd3afc4 ("scripts: allow to use separate file with hosts parameters")
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>