### PR TITLE
Dev

### DIFF
--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -329,3 +329,38 @@ else
 fi
 # Use the same ta_rpcprovider for non-IUT hosts
 export SF_TS_TST_RPCPROVIDER=ta_rpcs
+
+if ! ${ST_IUT_IS_CMOD} ; then
+
+    if [[ -n "$SF_TS_TMPDIR" ]] ; then
+        if [[ -z "$TE_WORKSPACE_DIR" ]] ; then
+            export TE_WORKSPACE_DIR="$SF_TS_TMPDIR"
+        fi
+
+        # Create dir on all hosts from configuration if SF_TS_TMPDIR is exported
+        hosts="$TE_IUT $TE_TST1 $TE_TST2 $TE_LOG_LISTENER"
+        for host in $ts_host_names ; do
+            ssh $host mkdir -p $SF_TS_TMPDIR
+        done
+    fi
+
+    # List of hosts from the testing triangle
+    hosts="$TE_IUT $TE_TST1 $TE_TST2"
+
+    if ! ${ST_IGNORE_NM} ; then
+        for curr_host in ${hosts}; do
+            [ -n "`ssh $curr_host ps aux 2>/dev/null | egrep NetworkManager.*/var/run/NetworkManager | grep -v grep`" ] || continue
+            echo "NetworkManager is running on $curr_host. Use --ignore-nm to suppress warning."
+            exit 1
+        done
+    fi
+
+    if ! ${ST_IGNORE_ZEROCONF} ]] ; then
+        for curr_host in ${hosts}; do
+            [ -n "`ssh $curr_host /sbin/route 2>/dev/null | grep ^link-local`" ] || continue
+            echo "ZEROCONF is enabled on $curr_host. Use --ignore-zeroconf to suppress warning."
+            echo "Add 'NOZEROCONF=yes' line to /etc/sysconfig/network to disable ZEROCONF."
+            exit 1
+        done
+    fi
+fi

--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -5,7 +5,13 @@
 # configuration.
 #
 . ${SF_TS_CONFDIR}/scripts/sfc_onload_gnu
-. ${TE_TS_RIGSDIR}/scripts/lib.run
+
+# Include the file if it really exists - this allows sapi-ts not to break.
+# It seems that the following functions may become unavailable on some
+# TE_TS_RIGSDIR implementations: 'scp_dir', 'ln_sf_safe'.
+[[ -e "${TE_TS_RIGSDIR}/scripts/lib.run" ]] \
+    && source "${TE_TS_RIGSDIR}/scripts/lib.run"
+
 . ${SF_TS_CONFDIR}/scripts/ipvlan
 . ${SF_TS_CONFDIR}/scripts/sfptpd
 

--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -16,6 +16,16 @@
 . ${SF_TS_CONFDIR}/scripts/ipvlan
 . ${SF_TS_CONFDIR}/scripts/sfptpd
 
+source "${TE_BASE}/scripts/lib"
+file_to_src="${TE_TS_RIGSDIR}/scripts/lib/ts_funcs"
+[[ -f "$src_file" ]] &&  source "$src_file"
+
+#
+# The called function can export the following variables:
+# LIBBPF_SRC, SF_TS_PINGPONG_IUT and SF_TS_PINGPONG_TST.
+#
+call_if_defined export_sapi_ts_site_envs
+
 guess_libdir="/usr/lib"
 
 #######################################
@@ -362,5 +372,15 @@ if ! ${ST_IUT_IS_CMOD} ; then
             echo "Add 'NOZEROCONF=yes' line to /etc/sysconfig/network to disable ZEROCONF."
             exit 1
         done
+    fi
+
+    if [[ -z "$SF_TS_CMDCLIENT" ]] ; then
+        call_if_defined export_cmdclient "$TE_IUT"
+    fi
+
+    # Note: firmware variants (full/low) applicable for sfc driver only
+    if [[ "$TE_ENV_IUT_NET_DRIVER" == "sfc" ]] ; then
+        export_iut_fw_version "$TE_IUT" "$TE_IUT_TST1"
+        check_fw_var_consistency
     fi
 fi

--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -12,10 +12,29 @@
 [[ -e "${TE_TS_RIGSDIR}/scripts/lib.run" ]] \
     && source "${TE_TS_RIGSDIR}/scripts/lib.run"
 
+. ${SF_TS_CONFDIR}/scripts/lib
 . ${SF_TS_CONFDIR}/scripts/ipvlan
 . ${SF_TS_CONFDIR}/scripts/sfptpd
 
 guess_libdir="/usr/lib"
+
+#######################################
+# Copy a file/directory from a remote host to a local
+# directory using rsync.
+# Arguments:
+#   Host name
+#   Source
+#   Destination
+# Returns:
+#   Status code from rsync tool
+#######################################
+rsync_from() {
+    local host="$1" ; shift
+    local from="$1" ; shift
+    local to="$1" ; shift
+
+    rsync -q -c -r "${host}:${from}" "$(dirname ${to})"
+}
 
 case "$IUT_KERNEL_NAME" in
     Linux )
@@ -186,7 +205,7 @@ fi
 if test -n "${SFC_ONLOAD_GNU}" -a -z "${SFC_PROFILE_DIR}" ; then
     if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
         export SFC_PROFILE_DIR="${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/onload_profiles"
-        scp_dir "$TE_IUT" \
+        rsync_from "$TE_IUT" \
                 "${SFC_ONLOAD_GNU}/../../scripts/onload_profiles" \
                 "$SFC_PROFILE_DIR"
     else
@@ -212,7 +231,7 @@ for header in extensions.h extensions_zc.h extensions_timestamping.h extensions_
     if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
         local_file="${SFC_ONLOAD_EXT_HEADERS}/${header}"
         target="${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/copied_headers/${header}"
-        scp_dir "$TE_IUT" "$local_file" "$target"
+        rsync_from "$TE_IUT" "$local_file" "$target"
     else
         target="${SFC_ONLOAD_EXT_HEADERS}/${header}"
     fi
@@ -223,10 +242,10 @@ done
 
 if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
 
-    scp_dir "$TE_IUT" "${SFC_ONLOAD_EXT_HEADERS}" \
+    rsync_from "$TE_IUT" "${SFC_ONLOAD_EXT_HEADERS}" \
             "${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/copied_headers/onload"
 
-    scp_dir "$TE_IUT" "${SFC_ONLOAD_EXT_HEADERS}/../etherfabric" \
+    rsync_from "$TE_IUT" "${SFC_ONLOAD_EXT_HEADERS}/../etherfabric" \
             "${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/copied_headers/etherfabric"
 
     # Make link to "onload" folder itself, as headers in it may contain

--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # (c) Copyright 2004 - 2022 Xilinx, Inc. All rights reserved.
-cfg="$1" ; shift
+iut_drv="$1" ; shift
+iut_dut="$1" ; shift
 ool_set=" $@ "
 
 ring() {
@@ -174,25 +175,6 @@ ool_put_before() {
     fi
 }
 
-#
-# Check whether a configuration is a specific DUT.
-# Checking is perfomed by searhing "--script=dut/<dut>" lines in configuration
-# file - TE_TS_RIGSDIR/run/<cfg>.
-#
-# Argumens:
-#   cfg - configuration name
-#   dut - dut name, for example ef100_soc
-#
-# Return: 0 if 'cfg' has 'dut', 1 otherwise
-#
-cfg_is_dut () {
-    local cfg=$1
-    local dut=$2
-    local rc=$(grep -c --line-regexp -e --script=dut/$dut $TE_TS_RIGSDIR/run/$cfg)
-
-    [[ -n "$rc" && "$rc" != "0" ]] && return 0 || return 1
-}
-
 function syscall_fix()
 {
     # Bug 81775 comment 1: syscall is supported for x86_64-only
@@ -204,7 +186,7 @@ function syscall_fix()
 
 function ef100soc_fix()
 {
-    if cfg_is_dut "$cfg" "ef100_soc" ; then
+    if [[ "$iut_dut" == "ef100_soc" ]] ; then
         # ON-13715: there are few VIs available for EF100 SOC, so we should
         # avoid creating too much stacks.
         if ! ool_contains "reuse_stack" ; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -81,7 +81,6 @@ RUN_OPTS="${RUN_OPTS} --tester-only-req-logues"
 ST_IGNORE_NM=false
 ST_IGNORE_ZEROCONF=false
 ST_IUT_IS_CMOD=false
-is_nonsf=false
 cfg_sfx=""
 while test -n "$1" ; do
     if call_if_defined grab_cfg_check_opt "$1" ; then
@@ -134,7 +133,7 @@ while test -n "$1" ; do
         # Use cfg without '-mlx' as hostname
         hostname="${cfg/%-mlx/}"
         if test "x$hostname" != "x$cfg" ; then
-            is_mlx=true
+            cfg_sfx="${cfg/${hostname}-/}"
         fi
 
         RUN_OPTS="${RUN_OPTS} --opts=run/$cfg"
@@ -225,20 +224,6 @@ OOL_SET=$(${RUNDIR}/scripts/ool_fix_consistency.sh $hostname "$cfg_sfx" $OOL_SET
 AUX_REQS=$(${RUNDIR}/scripts/ool_fix_reqs.py --ools="$OOL_SET" --cfg_sfx="$cfg_sfx")
 RUN_OPTS="${RUN_OPTS} ${AUX_REQS}"
 
-if ! $ST_IUT_IS_CMOD && ! $is_nonsf ; then
-    export_cmdclient $hostname
-
-    # Note: firmware variants (full/low) applicable for sfc only
-    iut_ifs=( $(get_sfx_ifs $hostname sfc "") )
-    export_iut_fw_version $hostname ${iut_ifs[0]}
-fi
-
-if ! $is_mlx ; then
-    OOL_SET=$(fw_var_consistency $OOL_SET)
-    if test $? -eq 1 ; then
-        exit 1
-    fi
-fi
 RUN_OPTS="$RUN_OPTS $OOL_PROFILE"
 for i in $OOL_SET ; do
     if [[ "$i" == "hwport2" ]] ; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,7 +10,12 @@ popd >/dev/null
 [ "$(basename $RUNDIR)" = "scripts" ] && RUNDIR="$(realpath "${RUNDIR}/..")"
 [ -e "${RUNDIR}/scripts/guess.sh" ] && source "${RUNDIR}/scripts/guess.sh"
 
-. ${TE_TS_RIGSDIR}/scripts/lib.run
+# Include the file if it really exists - this allows sapi-ts not to break.
+# It seems that the following functions may become unavailable on some
+# TE_TS_RIGSDIR implementations: 'export_cmdclient', 'get_sfx_ifs' and
+# 'export_iut_fw_version'.
+[[ -e "${TE_TS_RIGSDIR}/scripts/lib.run" ]] \
+    && source "${TE_TS_RIGSDIR}/scripts/lib.run"
 
 if test -z "${TE_TS_SOCKAPI}" -a -d "${RUNDIR}/sockapi-ts" ; then
     export TE_TS_SOCKAPI="${RUNDIR}/sockapi-ts"


### PR DESCRIPTION
This patch series should be used and tested in conjunction with the patch series in https://github.com/ol-damirm/cns-ts-conf/commits/dev.
Each individual patch allows you to eliminate possible problems with the running of sapi-ts.
Together, they allow you to run sapi-ts with a local TE_TS_RIGS directory.
I used the following command line:
```shell
./run.sh -q --cfg=<my-cfg-name> --tester-run=sockapi-ts/usecases/send_recv --ool=onload
```