### PR TITLE
ts: replace deprecated file path functions with modern ones

### DIFF
--- a/sockapi-ts/basic/socket_via_af_unix_read.c
+++ b/sockapi-ts/basic/socket_via_af_unix_read.c
@@ -63,7 +63,7 @@ main(int argc, char *argv[])
     struct cmsghdr *cmsg_tx;
     struct cmsghdr *cmsg_rx;
     struct sockaddr_un us_addr;
-    char *us_file_name = NULL;
+    te_string us_file_name = TE_STRING_BUF_INIT(us_addr.sun_path);
 
     void *tx_buf = NULL;
     void *rx_buf = NULL;
@@ -112,8 +112,7 @@ main(int argc, char *argv[])
                          RPC_PROTO_DEF);
 
     us_addr.sun_family = AF_UNIX;
-    us_file_name = tapi_file_generate_name();
-    strncpy(us_addr.sun_path, us_file_name, sizeof(us_addr.sun_path));
+    tapi_file_make_name(&us_file_name);
 
     rpc_bind(pco_iut2, iut2_us, (struct sockaddr *)&us_addr);
 

--- a/sockapi-ts/basic/socket_via_af_unix_write.c
+++ b/sockapi-ts/basic/socket_via_af_unix_write.c
@@ -62,7 +62,7 @@ main(int argc, char *argv[])
     struct cmsghdr *cmsg_tx;
     struct cmsghdr *cmsg_rx;
     struct sockaddr_un us_addr;
-    char *us_file_name = NULL;
+    te_string us_file_name = TE_STRING_BUF_INIT(us_addr.sun_path);
 
     void *tx_buf = NULL;
     void *rx_buf = NULL;
@@ -121,8 +121,7 @@ main(int argc, char *argv[])
                          RPC_PROTO_DEF);
 
     us_addr.sun_family = AF_UNIX;
-    us_file_name = tapi_file_generate_name();
-    strncpy(us_addr.sun_path, us_file_name, sizeof(us_addr.sun_path));
+    tapi_file_make_name(&us_file_name);
 
     rpc_bind(pco_iut2, iut2_us, (struct sockaddr *)&us_addr);
 

--- a/sockapi-ts/level5/fd_caching/fd_cache_dup.c
+++ b/sockapi-ts/level5/fd_caching/fd_cache_dup.c
@@ -95,6 +95,7 @@ dup_unix(rcf_rpc_server *rpcs, int sock)
     int                 rpcs1_us = -1;
     int                 rpcs2_us = -1;
     struct sockaddr_un  us_addr;
+    te_string           us_filename = TE_STRING_BUF_INIT(us_addr.sun_path);
 
     memset(&msg, 0, sizeof(msg));
     memset(&us_addr, 0, sizeof(us_addr));
@@ -106,8 +107,7 @@ dup_unix(rcf_rpc_server *rpcs, int sock)
                          RPC_PROTO_DEF);
 
     us_addr.sun_family = AF_UNIX;
-    snprintf(us_addr.sun_path, sizeof(us_addr.sun_path),
-             "/tmp/%s_share_usocket", tapi_file_generate_name());
+    tapi_file_make_custom_pathname(&us_filename, "/tmp", "_share_usocket");
 
     rpc_bind(rpcs, rpcs2_us, (struct sockaddr *)&us_addr);
     rpc_connect(rpcs, rpcs1_us, (struct sockaddr *)&us_addr);

--- a/sockapi-ts/lib/sockapi-ts.c
+++ b/sockapi-ts/lib/sockapi-ts.c
@@ -1838,6 +1838,7 @@ sockts_share_socket_2proc(rcf_rpc_server *rpcs1, rcf_rpc_server *rpcs2,
     int                 rpcs1_us = -1;
     int                 rpcs2_us = -1;
     struct sockaddr_un  us_addr;
+    te_string           us_path = TE_STRING_BUF_INIT(us_addr.sun_path);
     char                rmcmd[sizeof(us_addr.sun_path) + 4];
 
     memset(&msg, 0, sizeof(msg));
@@ -1850,8 +1851,7 @@ sockts_share_socket_2proc(rcf_rpc_server *rpcs1, rcf_rpc_server *rpcs2,
                          RPC_PROTO_DEF);
 
     us_addr.sun_family = AF_UNIX;
-    snprintf(us_addr.sun_path, sizeof(us_addr.sun_path),
-             "/tmp/%s_share_usocket", tapi_file_generate_name());
+    tapi_file_make_custom_pathname(&us_path, "/tmp", "_share_usocket");
 
     rpc_bind(rpcs2, rpcs2_us, (struct sockaddr *)&us_addr);
     rpc_connect(rpcs1, rpcs1_us, (struct sockaddr *)&us_addr);

--- a/sockapi-ts/tcp/syn_sent_func.c
+++ b/sockapi-ts/tcp/syn_sent_func.c
@@ -101,7 +101,7 @@ main(int argc, char *argv[])
     te_bool is_shutdown_close_func = FALSE;
     te_bool is_send_recv_func = FALSE;
 
-    char *sendfile_fn = NULL;
+    te_string sendfile_fn = TE_STRING_INIT;
     int sendfile_fd = -1;
     te_bool file_created = FALSE;
 
@@ -123,8 +123,8 @@ main(int argc, char *argv[])
     {
         TEST_STEP("If @p test_func is @b sendfile(), create a file "
                   "on IUT to send.");
-        CHECK_NOT_NULL(sendfile_fn = tapi_file_generate_name());
-        RPC_FOPEN_D(sendfile_fd, pco_iut, sendfile_fn,
+        tapi_file_make_name(&sendfile_fn);
+        RPC_FOPEN_D(sendfile_fd, pco_iut, sendfile_fn.ptr,
                     RPC_O_RDWR | RPC_O_CREAT, 0);
         file_created = TRUE;
         rpc_write(pco_iut, sendfile_fd, send_data, PKT_LEN);
@@ -577,7 +577,7 @@ cleanup:
     CLEANUP_RPC_CLOSE(pco_tst, tst_s);
 
     if (file_created)
-        REMOVE_REMOTE_FILE(pco_iut->ta, sendfile_fn);
+        REMOVE_REMOTE_FILE(pco_iut->ta, sendfile_fn.ptr);
 
     TEST_END;
 }


### PR DESCRIPTION
Recently TE has deprecated old and unsafe tapi_file_generate_name(). The patch replaces it with a proper replacement with no functional changes. Several occurrences of it are still retained in 'services' subdirectory, as the code there is never compiled anyway.

Signed-off-by: Artem Andreev <artem.andreev@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

Testing Done: `./run.sh --cfg={our local cfg name} --tester-run=sockapi-ts/basic/socket_via_af_unix_read`. The patch does not change any runtime behaviour, so it can be verified on any configuration, incl. pure Linux.