### PR TITLE
scripts: follow changes in the ts-conf repository

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -118,7 +118,7 @@ get_cfg_env() {
         process_env_scripts "$cfg_env_scripts"
 
         if [[ -r "${SF_TS_CONFDIR}/scripts/nic-pci2dut" ]] ; then
-            # Obtain TE_ENV_IUT_EF_DUT and TE_ENV_TST1_EF_DUT variables
+            # Obtain TE_ENV_IUT_DUT and TE_ENV_TST1_DUT variables
             source "${SF_TS_CONFDIR}/scripts/nic-pci2dut"
         fi
 
@@ -269,8 +269,8 @@ fi
 
 
 iut_drv="$(get_cfg_env ${cfg} TE_ENV_IUT_NET_DRIVER)"
-iut_dut="$(get_cfg_env ${cfg} TE_ENV_IUT_EF_DUT)"
-OOL_SET=$(${RUNDIR}/scripts/ool_fix_consistency.sh $iut_drv $iut_dut $OOL_SET)
+iut_dut="$(get_cfg_env ${cfg} TE_ENV_IUT_DUT)"
+OOL_SET=$(${RUNDIR}/scripts/ool_fix_consistency.sh "$iut_drv" "$iut_dut" $OOL_SET)
 AUX_REQS=$(${RUNDIR}/scripts/ool_fix_reqs.py --ools="$OOL_SET")
 RUN_OPTS="${RUN_OPTS} ${AUX_REQS}"
 


### PR DESCRIPTION
The variable TE_ENV_IUT_EF_DUT has been renamed to TE_ENV_IUT_DUT since the sapi-ts, in general, can be run on network adapters from various manufacturers.

Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>
Reviewed-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>

------------
Checked with the following command line (tests are running now):
```shell
./run.sh -n --cfg=<my-cfg> --ool=socket_cache --ool=onload \
--tester-run=sockapi-ts/level5/fd_caching/fd_cache_nonblock_sync:env=VAR.env.peer2peer_two_iut,use_libc=TRUE,check_first=FALSE,nonblock_first=TRUE,nonblock_func=fcntl,func=read
```