### PR TITLE
ts: use the proper variable type to work with memlock

### DIFF
--- a/sockapi-ts/bpf/prologue.c
+++ b/sockapi-ts/bpf/prologue.c
@@ -68,7 +68,7 @@ main(int argc, char *argv[])
     TEST_STEP("Increase @b RLIMIT_MEMLOCK up to @c SOCKTS_BPF_RLIMITS_MEMLOCK "
               "value.");
     sockts_bpf_set_rlim_memlock(pco_used,
-                                (unsigned int)SOCKTS_BPF_RLIMITS_MEMLOCK);
+                                (uint64_t)SOCKTS_BPF_RLIMITS_MEMLOCK);
 
     TEST_STEP("Set @b cplane_track_xdp to @c Y");
     set_cplane_track_xdp(pco_used);

--- a/sockapi-ts/congestion/prologue.c
+++ b/sockapi-ts/congestion/prologue.c
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
     TEST_STEP("Increase @b RLIMIT_MEMLOCK up to @c SOCKTS_BPF_RLIMITS_MEMLOCK "
               "value on TST.");
     sockts_bpf_set_rlim_memlock(pco_tst,
-                                (unsigned int)SOCKTS_BPF_RLIMITS_MEMLOCK);
+                                (uint64_t)SOCKTS_BPF_RLIMITS_MEMLOCK);
 
     TEST_SUCCESS;
 

--- a/sockapi-ts/lib/sockapi-ts_bpf.c
+++ b/sockapi-ts/lib/sockapi-ts_bpf.c
@@ -379,23 +379,22 @@ sockts_bpf_prog_unlink(rcf_rpc_server *rpcs,
 
 /* See description in sockts_bpf.h */
 void
-sockts_bpf_set_rlim_memlock(rcf_rpc_server *rpcs, unsigned int value)
+sockts_bpf_set_rlim_memlock(rcf_rpc_server *rpcs, uint64_t value)
 {
-    cfg_val_type    val_t_int = CVT_INTEGER;
-    unsigned int    memlock_cur, memlock_max;
+    uint64_t    memlock_cur, memlock_max;
 
-    CHECK_RC(cfg_get_instance_fmt(&val_t_int, &memlock_cur,
+    CHECK_RC(cfg_get_uint64(&memlock_cur,
                         "/agent:%s/rlimits:/memlock:/cur:", rpcs->ta));
-    CHECK_RC(cfg_get_instance_fmt(&val_t_int, &memlock_max,
+    CHECK_RC(cfg_get_uint64(&memlock_max,
                         "/agent:%s/rlimits:/memlock:/max:", rpcs->ta));
 
     if (memlock_cur != value || memlock_max != value)
     {
         RING("Current rlimits/memlock values: cur=%u, max=%u", memlock_cur,
              memlock_max);
-        CHECK_RC(cfg_set_instance_fmt(val_t_int, &value,
+        CHECK_RC(cfg_set_instance_fmt(CFG_VAL(UINT64, value),
                         "/agent:%s/rlimits:/memlock:/max:", rpcs->ta));
-        CHECK_RC(cfg_set_instance_fmt(val_t_int, &value,
+        CHECK_RC(cfg_set_instance_fmt(CFG_VAL(UINT64, value),
                         "/agent:%s/rlimits:/memlock:/cur:", rpcs->ta));
     }
 }

--- a/sockapi-ts/lib/sockapi-ts_bpf.h
+++ b/sockapi-ts/lib/sockapi-ts_bpf.h
@@ -231,7 +231,7 @@ sockts_bpf_unlink_xdp(rcf_rpc_server *rpcs,
  * @param value         New value to set
  */
 extern void sockts_bpf_set_rlim_memlock(rcf_rpc_server *rpcs,
-                                        unsigned int value);
+                                        uint64_t value);
 
 /**
  * Convert key/values of the map to string representation, where are both


### PR DESCRIPTION
The rlimits/memlock type was changed in TE from int32 to uint64.

Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>

-------------
Testing done:
The congestion/prologue is green now, but before this patch there is the following error:
```shell
Test Failed in ../../../sockapi-ts/lib/sockapi-ts_bpf.c, line 387, sockts_bpf_set_rlim_memlock()
line 387: cfg_get_instance_fmt(&val_t_int, &memlock_cur, "/agent:%s/rlimits:/memlock:/cur:", rpcs->ta)
returns 0x10400388 (CONF_API-EBADTYPE), but expected 0
```