### PR TITLE
sockapi-ts/multicast: fix getting instance value

### DIFF
--- a/sockapi-ts/multicast/ip_multicast_if.c
+++ b/sockapi-ts/multicast/ip_multicast_if.c
@@ -85,10 +85,10 @@ do {                                                                        \
     inet_ntop(_addr->sa_family,                                             \
               te_sockaddr_get_netaddr(_addr),                               \
               addr_str, sizeof(addr_str));                                  \
-    _addr_on_if = (cfg_get_instance_fmt(CVT_INTEGER, &inst,                 \
-                                       "/agent:%s/interface:%s/net_addr:%s",\
-                                       _rpcs->ta, _if->if_name,             \
-                                       addr_str) == 0);                     \
+    _addr_on_if = (cfg_get_int32(&inst,                                     \
+                                 "/agent:%s/interface:%s/net_addr:%s",      \
+                                 _rpcs->ta, _if->if_name,                   \
+                                 addr_str) == 0);                           \
 } while (0)
 
 int
@@ -129,7 +129,7 @@ main(int argc, char *argv[])
     size_t                     buf_len;
     struct tarpc_mreqn         mreq;
     const char                *opt_param = NULL;
-    int                        inst;
+    int32_t                    inst;
     cfg_handle                 rh1 = CFG_HANDLE_INVALID;
     cfg_handle                 rh2 = CFG_HANDLE_INVALID;
     int                        route_prefix;

--- a/sockapi-ts/multicast/mcast_route.c
+++ b/sockapi-ts/multicast/mcast_route.c
@@ -75,7 +75,7 @@ main(int argc, char *argv[])
     cfg_handle             route_handle;
     char                  *sendbuf = NULL;
     char                  *recvbuf = NULL;
-    int                    inst;
+    int32_t                inst;
     char                   src_addr_char[INET6_ADDRSTRLEN];
     te_bool                connect_iut;
     te_bool                sock_readable;
@@ -195,10 +195,8 @@ main(int argc, char *argv[])
     CHECK_NOT_NULL(inet_ntop(af, te_sockaddr_get_netaddr(SA(&src_addr)),
                              src_addr_char, INET6_ADDRSTRLEN));
 
-    if (cfg_get_instance_fmt(CVT_INTEGER, &inst,
-                             "/agent:%s/interface:%s/net_addr:%s",
-                             pco_iut->ta, iut_if->if_name,
-                             src_addr_char) != 0)
+    if (cfg_get_int32(&inst, "/agent:%s/interface:%s/net_addr:%s",
+                      pco_iut->ta, iut_if->if_name, src_addr_char) != 0)
     {
         TEST_FAIL("Some other interface was used to send");
     }


### PR DESCRIPTION
Pointer to cfg_val_type should be passed as an argument to cfg_get_instance() instead of a constant. Moreover here we use new function cfg_get_int32().

OL-Redmine-Id: 11890
Signed-off-by: Nikolai Kosovskii <nikolai.kosovskii@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

---
Testing done:

Checked with sapi-ts running
`./run.sh -q --cfg=<my-cfg>  --build-only
`
https://github.com/oktetlabs/sapi-ts/commit/c58b64db60c6ed24b2d568cda521d2c49ac22ac6