### PR TITLE
conf/scripts: fix annoying typos

### DIFF
--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -347,7 +347,7 @@ if ! ${ST_IUT_IS_CMOD} ; then
 
         # Create dir on all hosts from configuration if SF_TS_TMPDIR is exported
         hosts="$TE_IUT $TE_TST1 $TE_TST2 $TE_LOG_LISTENER"
-        for host in $ts_host_names ; do
+        for host in $hosts ; do
             ssh $host mkdir -p $SF_TS_TMPDIR
         done
     fi
@@ -363,7 +363,7 @@ if ! ${ST_IUT_IS_CMOD} ; then
         done
     fi
 
-    if ! ${ST_IGNORE_ZEROCONF} ]] ; then
+    if ! ${ST_IGNORE_ZEROCONF} ; then
         for curr_host in ${hosts}; do
             [ -n "`ssh $curr_host /sbin/route 2>/dev/null | grep ^link-local`" ] || continue
             echo "ZEROCONF is enabled on $curr_host. Use --ignore-zeroconf to suppress warning."


### PR DESCRIPTION
OL-Redmine-Id: 12265
Fixes: 44849548a0ea ("scripts: move processing hosts to a right place")
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

-----
Testing done:
- the `shellcheck --shell=bash --severity=warning conf/scripts/sockapi-ts` is silent now on these lines;
- the `SF_TS_TMPDIR` directory is created now on all hosts.
