### PR TITLE
Rename the af_xdp_single option to af_xdp_no_filters and allow testing it on all NICs

### DIFF
--- a/scripts/gen_onload_part.py
+++ b/scripts/gen_onload_part.py
@@ -116,7 +116,7 @@ def fix_testing_parms(host, ools, reqs, sl, slice_name,
     if older_then(branch, "onload-7.1"):
         remove_silent(ools, "laddr_prefsrc")
     if older_then(branch, "onload-8.0"):
-        remove_silent(ools, "af_xdp_single", "af_xdp", "zc_af_xdp")
+        remove_silent(ools, "af_xdp_no_filters", "af_xdp", "zc_af_xdp")
 
     # Remove ipvlan and macvlan before checking netns_iut + bond
     if host in params["no_ipvlan"]:
@@ -149,7 +149,7 @@ def fix_testing_parms(host, ools, reqs, sl, slice_name,
         remove_silent(ools, "m32")
     if host in params["no_af_xdp"]:
         remove_silent(ools, "af_xdp")
-        remove_silent(ools, "af_xdp_single")
+        remove_silent(ools, "af_xdp_no_filters")
         remove_silent(ools, "zc_af_xdp")
     if host in params["no_syscall"]:
         remove_silent(ools, "syscall")
@@ -179,7 +179,7 @@ def fix_testing_parms(host, ools, reqs, sl, slice_name,
         remove_silent(ools, "safe", "scalable_active_passive",
                       "scalable_active", "scalable_passive")
         # Scalable filters are not supported with AF_XDP. ST-2231.
-        remove_silent(ools, "af_xdp_single", "af_xdp", "zc_af_xdp")
+        remove_silent(ools, "af_xdp_no_filters", "af_xdp", "zc_af_xdp")
     # sleep_spin requires epoll3
     if "epoll3" not in ools:
         remove_silent(ools, "sleep_spin")
@@ -214,7 +214,7 @@ def fix_testing_parms(host, ools, reqs, sl, slice_name,
 
     # AF_XDP is tested with reuse_pco or reuse_stack only.
     # Remove cplane_server_grace_timeout_zero for reasons described above
-    if "af_xdp" in ools or "af_xdp_single" in ools:
+    if "af_xdp" in ools or "af_xdp_no_filters" in ools:
         remove_silent(ools, "cplane_server_grace_timeout_zero")
 
     # Note: x3 testing available starting from onload-8.0 branch
@@ -289,7 +289,7 @@ def gen_testing_part(rand, part_id, host, branch=None, parts_num_only=False,
 
     # Generate random ool params for testing
     test_ool = gen_ools(rand, "ool_params_freqs.yaml")
-    if af_xdp_strict and "af_xdp" not in test_ool and "af_xdp_single" not in test_ool:
+    if af_xdp_strict and "af_xdp" not in test_ool and "af_xdp_no_filters" not in test_ool:
         test_ool += ["af_xdp"]
         # We can't remove af_xdp in such case, so let's remove transparent
         # slice

--- a/scripts/gen_onload_part.py
+++ b/scripts/gen_onload_part.py
@@ -289,9 +289,7 @@ def gen_testing_part(rand, part_id, host, branch=None, parts_num_only=False,
 
     # Generate random ool params for testing
     test_ool = gen_ools(rand, "ool_params_freqs.yaml")
-    if af_xdp_strict and "af_xdp" not in test_ool:
-        # We do not use af_xdp_single on non-SFC NICs for now
-        remove_silent(test_ool, "af_xdp_single")
+    if af_xdp_strict and "af_xdp" not in test_ool and "af_xdp_single" not in test_ool:
         test_ool += ["af_xdp"]
         # We can't remove af_xdp in such case, so let's remove transparent
         # slice

--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -505,12 +505,12 @@ function af_xdp_fix()
 
         # AF_XDP is stable with reuse_pco only if reuse_stack option
         # is not presented.
-        # af_xdp_single option should be tested with reuse_stack only.
+        # af_xdp_no_filters option should be tested with reuse_stack only.
         # ON-12446.
         if ! ool_contains "reuse_stack" ; then
-            if ool_contains "af_xdp_single" ; then
+            if ool_contains "af_xdp_no_filters" ; then
                 ool_add "reuse_stack" \
-                    "$info/ON-12446: use af_xdp_single with reuse_stack only"
+                    "$info/ON-12446: use af_xdp_no_filters with reuse_stack only"
             else
                 ool_replace "no_reuse_pco" "reuse_pco" \
                     "$info: without reuse_stack, it is stable only with reuse_pco"

--- a/scripts/ool_fix_reqs.py
+++ b/scripts/ool_fix_reqs.py
@@ -89,16 +89,16 @@ if (("default_epoll" in ools or "default_epoll_pwait" in ools) and
 
 # AF_XDP does not hand IPv6 sockets over to the kernel stack with
 # ulhelper build in single queue mode. ON-12581.
-if "af_xdp_single" in ools and "build_ulhelper" in ools:
-    add_req("!IP6", "ON-12581: af_xdp_single + build_ulhelper")
+if "af_xdp_no_filters" in ools and "build_ulhelper" in ools:
+    add_req("!IP6", "ON-12581: af_xdp_no_filters + build_ulhelper")
 
-# af_xdp_single supports only one stack. See ST-2164.
-if "af_xdp_single" in ools and "reuse_stack" not in ools:
-    af_xdp_single_reason = "ST-2164: af_xdp_single supports only one stack"
-    add_req("!PIPE", af_xdp_single_reason)
-    add_req("!EXEC", af_xdp_single_reason)
-    add_req("!SO_LINGER", af_xdp_single_reason)
-    add_req("!ENV-LOOPBACK", af_xdp_single_reason)
+# af_xdp_no_filters supports only one stack. See ST-2164.
+if "af_xdp_no_filters" in ools and "reuse_stack" not in ools:
+    af_xdp_no_filters_reason = "ST-2164: af_xdp_no_filters supports only one stack"
+    add_req("!PIPE", af_xdp_no_filters_reason)
+    add_req("!EXEC", af_xdp_no_filters_reason)
+    add_req("!SO_LINGER", af_xdp_no_filters_reason)
+    add_req("!ENV-LOOPBACK", af_xdp_no_filters_reason)
 
 # loop4 + m32 parameter combination leads to "out of memory" problem described
 # in ON-12690.

--- a/scripts/ool_params_freqs.yaml
+++ b/scripts/ool_params_freqs.yaml
@@ -43,7 +43,7 @@
 - {null: 3, disable_timestamps: 2}
 - {null: 5, fdtable_strict: 3, 'fdtable_strict,socket_cache': 2, socket_cache: 1}
 - {null: 2, int_spin: 1, small_spin: 1, spin: 1, tiny_spin: 1}
-- {null: 20, af_xdp: 1, 'af_xdp,zc_af_xdp': 1, af_xdp_single: 1, 'af_xdp_single,zc_af_xdp': 1}
+- {null: 20, af_xdp: 1, 'af_xdp,zc_af_xdp': 1, af_xdp_no_filters: 1, 'af_xdp_no_filters,zc_af_xdp': 1}
 - {null: 5, tcp_combine_send: 1}
 - {null: 3, use_chk_funcs: 1}
 - {null: 1, zc_reg_huge: 1, zc_reg_huge_align: 1}


### PR DESCRIPTION
Testing done:
```shell
# first patch checked with the following command line:
./gen_onload_part.py -a 1 1 <my-host> -x |grep af_xdp_single
# Before this patch I saw af_xdp option only.

# The second patch checked with the following command line:
for i in {1..100} ; do ./gen_onload_part.py -a $i 1 <my-host> -x |grep af_xdp ; done
# (and look at the output).
```