### PR TITLE
scripts: fix epollN + safe options order issue

### DIFF
--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -420,6 +420,24 @@ function sleep_spin_fix()
     fi
 }
 
+function safe_epoll_fix()
+{
+    # Replace "safe + epollN" options with a single "safe_epollN" option.
+    # It fixes the issue related to the order of these options - if "epollN"
+    # comes before "safe" we get a TRC tag that does not match the actual
+    # behavior, because safe profile does not overwrite EF_UL_EPOLL variable,
+    # but still adds the tag. That breaks epoll tests expectations.
+
+    local info="safe_epoll_fix"
+
+    if ool_contains "safe"; then
+        ool_replace "epoll0" "safe_epoll0" "$info"
+        ool_replace "epoll1" "safe_epoll1" "$info"
+        ool_replace "epoll3" "safe_epoll3" "$info"
+        ool_contains "safe_epoll*" && ool_remove "safe" "$info"
+    fi
+}
+
 function epoll_fix()
 {
     local info="epoll_fix"
@@ -600,6 +618,7 @@ disable_timestamps_fix
 pkt_nocomp_fix
 ipvlan_fix
 cplane_default_fix
+safe_epoll_fix
 # epoll_fix should be at the end but before branch_order_fix
 epoll_fix
 defaults_fix


### PR DESCRIPTION
Replace "safe + epollN" options with a single "safe_epollN" option. It fixes the issue related to the order of these options - if "epollN" comes before "safe" we get a TRC tag that does not match the actual behavior, because safe profile does not overwrite EF_UL_EPOLL variable, but still adds the tag. That breaks epoll tests expectations.

OL-Redmine-Id: 12437
Signed-off-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---

https://github.com/oktetlabs/sapi-ts/commit/aa418f237334260cab89c70e680543c594372b10

**Testing**:

Running the script:
```bash
# --ool=epoll3 --ool=safe became safe_epoll3
$ ./scripts/ool_fix_consistency.sh sfc ef10 epoll3 safe                                                                                                                              
RING: set reuse_pco by default: using --ool=reuse_pco                                                                                                                                             
RING: loop_fix: using --ool=loop0                                                                                                                                                                 
RING: loop_fix: using --ool=loop_linux                                                                                                                                                           
RING: reuse_pco_fix/Bug 74895: using --ool=one_cluster                                                                                                                                           
RING: cplane_default_fix: using --ool=cplane_log_to_kernel                                                                                                                                      
RING: safe_epoll_fix: replacing --ool=epoll3 with --ool=safe_epoll3                                                                                                                              
RING: safe_epoll_fix: removing --ool=safe                
safe_epoll3 reuse_pco loop0 loop_linux one_cluster cplane_log_to_kernel

# --ool=safe - nothing happens
$ ./scripts/ool_fix_consistency.sh sfc ef10 safe                                                                                                                                     
RING: set reuse_pco by default: using --ool=reuse_pco
RING: loop_fix: using --ool=loop0                                                                                                                                                                 
RING: loop_fix: using --ool=loop_linux                                                                                                                                                           
RING: reuse_pco_fix/Bug 74895: using --ool=one_cluster                                                                                                                                           
RING: cplane_default_fix: using --ool=cplane_log_to_kernel                                                                                                                                       
safe reuse_pco loop0 loop_linux one_cluster cplane_log_to_kernel                                                                                                                                 

# --ool=safe_epoll3 - nothing happens
$ ./scripts/ool_fix_consistency.sh sfc ef10 safe_epoll3                                                                                                                              
RING: set reuse_pco by default: using --ool=reuse_pco                 
RING: loop_fix: using --ool=loop0                                                                                                                                                                 
RING: loop_fix: using --ool=loop_linux                                                                                                                                                           
RING: reuse_pco_fix/Bug 74895: using --ool=one_cluster                                                   
RING: cplane_default_fix: using --ool=cplane_log_to_kernel                                               
safe_epoll3 reuse_pco loop0 loop_linux one_cluster cplane_log_to_kernel

# --ool=epoll3 - nothing happens
$ ./scripts/ool_fix_consistency.sh sfc ef10 epoll3                         
RING: set reuse_pco by default: using --ool=reuse_pco                     
RING: loop_fix: using --ool=loop0                                                                        
RING: loop_fix: using --ool=loop_linux                                                                   
RING: reuse_pco_fix/Bug 74895: using --ool=one_cluster                                                   
RING: cplane_default_fix: using --ool=cplane_log_to_kernel                                               
epoll3 reuse_pco loop0 loop_linux one_cluster cplane_log_to_kernel 
```

The test from epoll became green:
`--tester-run=sockapi-ts/epoll/epfd_in_itself --ool=epoll3 --ool=safe --ool=onload`