### PR TITLE
checksum/tcp_bad_csum_open: fix test timing issues

### DIFF
--- a/sockapi-ts/checksum/tcp_bad_csum_open.c
+++ b/sockapi-ts/checksum/tcp_bad_csum_open.c
@@ -290,6 +290,7 @@ main(int argc, char *argv[])
         TEST_STEP("Finish the connection establishment if @p segment is @c SYN "
                   "(send @c ACK from CSAP)");
         CHECK_RC(tapi_tcp_ack_all(tcp_conn));
+        TAPI_WAIT_NETWORK;
     }
 
     TEST_STEP("Check that the RPC call on IUT is unblocked");


### PR DESCRIPTION
Wait a little before checking that IUT accept() call is unblocked. Before the patch, we performed this check immediately after sending ACK from Tester. On some systems it might lead to failure with the verdict:
"accept call is still blocked after sending segment with valid checksum"

OL-Redmine-Id: 12655
Signed-off-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---

https://github.com/oktetlabs/sapi-ts/commit/db90c9048df4492d87132be0289ff1d4b08bd17d
**Testing**
running:
`--tester-run=sockapi-ts/checksum/tcp_bad_csum_open%1*10 --ool=onload --ool=tiny_spin --ool=af_xdp`
The test is green now