### PR TITLE
scripts: disable netns for the sfc driver with zc_af_xdp

### DIFF
--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -538,6 +538,12 @@ function af_xdp_fix()
         # Scalable filters are not supported
         ool_remove "scalable*" "$info: scalable filters are not supported"
 
+        if ool_contains "zc_af_xdp*" && ool_contains "netns_*" ; then
+            if [[ "$iut_drv" == "sfc" ]] ; then
+                ool_remove "netns_*" \
+                    "$info/SWNETLINUX-4809/Bug 11986: disable netns on SFC NICs with zc_af_xdp"
+            fi
+        fi
     else
         # zc_af_xdp should be used only with AF_XDP
         ool_remove "zc_af_xdp" \


### PR DESCRIPTION
The sfc + af_xdp + zc_af_xdp in network namespaces causes "BUG: kernel NULL pointer: RIP: 0010:efx_xdp".

OL-Redmine-Id: 11986
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---------
Testing done:
```
$ ./run.sh --no-item --cfg=my-host --ool=af_xdp --ool=zc_af_xdp --ool=netns_iut
...
RING: af_xdp_fix/SWNETLINUX-4809/Bug 11986: disable netns on SFC NICs with zc_af_xdp: removing --ool=netns_iut
...
```