### PR TITLE
ts: do not run sockopts/reuseaddr_tcp_2 with AF_XDP

### DIFF
--- a/sockapi-ts/sockopts/package.xml
+++ b/sockapi-ts/sockopts/package.xml
@@ -2066,6 +2066,9 @@
                 <req id="SO_REUSEADDR"/>
                 <req id="SOCK_STREAM"/>
                 <!--<req id="ENV-2PEERS"/>-->
+                <!-- ON-12491, Bug 12170: the test inserts the same hw filter twice,
+                     it is incompatible with AF_XDP (at least for now) -->
+                <req id="NO_AF_XDP"/>
             </script>
             <arg name="env">
                 <!-- pco_iut1 and pco_iut2 are in different processes -->


### PR DESCRIPTION
The test inserts the same hw filter twice, it is incompatible with AF_XDP (at least for now).

OL-Redmine-Id: 12170
Signed-off-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

------
Testing done:
```shell
./run.sh -q --cfg=my-cfg --tester-run=sockapi-ts/sockopts/reuseaddr_tcp_2 --ool=onload --ool=af_xdp
```
The test does not run.