### PR TITLE
basic/pthread_cancellation_point: disable the test

### DIFF
--- a/sockapi-ts/basic/package.xml
+++ b/sockapi-ts/basic/package.xml
@@ -3037,7 +3037,10 @@
 
         <run>
             <script name="pthread_cancellation_point" track_conf="silent">
-                <req id="THREADS"/>
+              <req id="THREADS"/>
+              <!-- ON-12970, Bug 11774: pthread cancellation is not properly
+                   supported by Onload. -->
+              <req id="BROKEN"/>
             </script>
             <arg name="env">
                 <value ref="env.peer2peer"/>


### PR DESCRIPTION
Pthread cancellation is not properly supported by Onload.

OL-Redmine-Id: 11774
Signed-off-by: Georgii Samoilov <georgii.samoilov@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>

---------
testing done with the following command line:
```shell
./run.sh --cfg=<my-cfg> --ool=onload --tester-req=\!BROKEN --tester-run=sockapi-ts/basic/pthread_cancellation_point
```