### PR TITLE
sockopts/tcp_quickack: add timeout to wait for CSAP to start

### DIFF
--- a/sockapi-ts/sockopts/tcp_quickack.c
+++ b/sockapi-ts/sockopts/tcp_quickack.c
@@ -118,6 +118,8 @@ main(int argc, char *argv[])
                                TAD_TIMEOUT_INF, 0,
                                RCF_TRRECV_PACKETS);
 
+    /* On some hosts 500 msec delay is not enough */
+    VSLEEP(1, "wait for CSAP to start");
 
     rpc_setsockopt(pco_iut, iut_s, RPC_TCP_QUICKACK, &opt_val);
     rpc_getsockopt(pco_iut, iut_s, RPC_TCP_QUICKACK, &opt_get);


### PR DESCRIPTION
Without this timeout, CSAP does not have time to start, and the test fails with error "ACKs are not sent immediately".

OL-Redmine-Id: 11816
Signed-off-by: Georgii Samoilov <georgii.samoilov@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

--------------
The following command line is green now:
```shell
./run.sh --cfg=<my-cfg> --tester-run=sockapi-ts/sockopts/tcp_quickack%bbd397513c0c925e5f35143a6f9f3d56*10 -n --tester-run-while=expected
```