### PR TITLE
sockapi-ts/sendrecv: fix logging and wait time to receive remaining data 

### DIFF
--- a/sockapi-ts/sendrecv/stream_iov_send.c
+++ b/sockapi-ts/sendrecv/stream_iov_send.c
@@ -168,10 +168,9 @@ execute_pattern(int n, rpc_gather_write_f func)
         size += len;
         if (size != size1 + size2)
         {
-            ERROR("Length of data received on the TST %d does not match to"
-                  " length of data sent from IUT");
-            INFO("%d bytes instead %d", size, size1 + size2);
-            TEST_STOP;
+            RING("%d bytes received instead of %d", size, size1 + size2);
+            TEST_VERDICT("Length of data received on the TST does not match to"
+                         " length of data sent from IUT");
         }
     }
     if (iovec_check(tx1, patterns[n].len1, rx_buf, size) < 0)

--- a/sockapi-ts/sendrecv/stream_iov_send.c
+++ b/sockapi-ts/sendrecv/stream_iov_send.c
@@ -157,8 +157,9 @@ execute_pattern(int n, rpc_gather_write_f func)
     if (size < size1 + size2)
     {
         int len;
-        
+
         WARN("Not all data are received");
+        TAPI_WAIT_NETWORK;
         len = rpc_read(pco_tst, tst_s, rx_buf + size, sizeof(rx_buf) - size);
         if (len < 0)
         {


### PR DESCRIPTION
We have encountered with such fails in nigth test logs:
```
24	RING	sendrecv/stream_iov_send	TAPI RPC	00:32:41.056	RPC (Agt_B,pco_tst[8]): read(7, 0x5596a5c11c20[1024], 1024, chk_func=TRUE) -> 100 (RPC-EBADF)
25	WARN	sendrecv/stream_iov_send	Self	00:32:41.056	Not all data are received
26	RING	sendrecv/stream_iov_send	TAPI RPC	00:32:41.091	RPC (Agt_B,pco_tst[9]): read(7, 0x5596a5c11c84[924], 924, chk_func=TRUE) -> 10 (RPC-EBADF)
27	ERROR	sendrecv/stream_iov_send	Self	00:32:41.091	Length of data received on the TST -1514633555 does not match to length of data sent from IUT
```

We can see that the ERROR message contains a strange negative number. The proposed patch fixes the issue;
To reproduce the failure is quite difficult because there is no consistency.

Anyway, running a cmd:
`./run.sh -q --cfg=fili-sfc --tester-run=sockapi-ts/sendrecv/stream_iov_send%a63c7cbdd55008bad85b2512ed5847ee --ool=onload`
I did an artificial failure just to show the output:
```
41	RING	sendrecv/stream_iov_send	Self	19:27:24.138	7 bytes received instead of 6
42	ERROR	sendrecv/stream_iov_send	Verdict	19:27:24.138	Length of data received on the TST does not match to length of data sent from IUT
```


Second patch provide more time before second attemppt to recieve remaining data;  
Build is ok.
OpenOnload: `ec56c3f3c05626a5ac8558753e0b83ab5babb570`
Open TE: `9df17bb39bfc97797d6edb03e5b68e6f02e2e5e2`