### PR TITLE
sockapi-ts: recreate stack and restart IUT

### DIFF
--- a/sockapi-ts/gateways_epilogue.c
+++ b/sockapi-ts/gateways_epilogue.c
@@ -17,6 +17,7 @@ int
 main(int argc, char *argv[])
 {
     tapi_route_gateway gw;
+    int af_xdp_zc = 0;
     TAPI_DECLARE_ROUTE_GATEWAY_PARAMS;
 
     TEST_START;
@@ -35,6 +36,13 @@ main(int argc, char *argv[])
     CHECK_RC(sockts_wait_for_if_up(pco_tst, tst_if->if_name));
     CHECK_RC(sockts_wait_for_if_up(pco_gw, gw_iut_if->if_name));
     CHECK_RC(sockts_wait_for_if_up(pco_gw, gw_tst_if->if_name));
+
+    if (tapi_sh_env_get_int(pco_iut, "EF_AF_XDP_ZEROCOPY", &af_xdp_zc) == 0 &&
+        af_xdp_zc == 1)
+    {
+        sockts_recreate_onload_stack(pco_iut);
+        rcf_rpc_server_restart(pco_iut);
+    }
 
     TEST_SUCCESS;
 


### PR DESCRIPTION
sfc and i40e drivers do not restore XDP state after down-up thus gateways_epilogue with af_xdp_no_filters + zc_af_xdp parameter combinations on intel/sfc configurations fails and crashes further testing. To avoid crashes in zc_af_xdp cases, we recreate onload stack and restart IUT directly in the test.

OL-Redmine-Id: 12053
Signed-off-by: Pavel Liulchak <pavel.liulchak@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

_______
Testing done:
OpenOnload: 23dfd4873bc66403a3c6315ea2513f9569d23b3e
Open TE: 9df17bb39bfc97797d6edb03e5b68e6f02e2e5e2

The patch is part of https://github.com/oktetlabs/sapi-ts
see [oktetlabs/sapi-ts@438274e1](https://github.com/oktetlabs/sapi-ts/commit/438274e14ecfbe8d5671881e7da02882c837194b)

cmd that shows further tests fail after gateways_epilogue:
`./run.sh -q --cfg=${my_sfc_cfg} --log-html=html --tester-run=sockapi-ts/tcp/fit_window_after_shrink%1df0de0749266b9ac5ac629b678dfa67 --tester-run=sockapi-ts/tcp/same_tuple_new_isn*3 --ool=onload --ool=af_xdp_no_filters --ool=zc_af_xdp`

we see failure of further tests before the patch:
```
--->>> Start Tester
Starting package sockapi-ts
Starting test prologue                                                             pass
Starting package tcp
Starting test tsa_gw_prologue                                                      pass
Starting test fit_window_after_shrink                                              pass
Starting test ../gateways_epilogue                                                 pass
Starting test same_tuple_new_isn                                                   FAILED
Starting test same_tuple_new_isn                                                   FAILED
Starting test same_tuple_new_isn                                                   FAILED
Starting test same_tuple_new_isn                                                   FAILED
Starting test same_tuple_new_isn                                                   FAILED
Starting test same_tuple_new_isn                                                   FAILED
Done package tcp FAILED
Starting test epilogue                                                             pass
Done package sockapi-ts FAILED
Done package sockapi-ts FAILED
```

everything goes smoothly with the proposing patch:
```
--->>> Start Tester
Starting package sockapi-ts
Starting test prologue                                                             pass
Starting package tcp
Starting test tsa_gw_prologue                                                      pass
Starting test fit_window_after_shrink                                              pass
Starting test ../gateways_epilogue                                                 pass
Starting test same_tuple_new_isn                                                   pass
Starting test same_tuple_new_isn                                                   pass
Starting test same_tuple_new_isn                                                   pass
Starting test same_tuple_new_isn                                                   pass
Starting test same_tuple_new_isn                                                   pass
Starting test same_tuple_new_isn                                                   pass
Done package tcp pass
Starting test epilogue                                                             pass
Done package sockapi-ts pass
```