### PR TITLE
scripts: always ignore the transparent part with AF_XDP

### DIFF
--- a/scripts/gen_onload_part.py
+++ b/scripts/gen_onload_part.py
@@ -294,8 +294,9 @@ def gen_testing_part(rand, part_id, host, branch=None, parts_num_only=False,
 
     # Generate random ool params for testing
     test_ool = gen_ools(rand, "ool_params_freqs.yaml")
-    if af_xdp_strict and "af_xdp" not in test_ool and "af_xdp_no_filters" not in test_ool:
-        test_ool += ["af_xdp"]
+    if af_xdp_strict:
+        if "af_xdp" not in test_ool and "af_xdp_no_filters" not in test_ool:
+            test_ool += ["af_xdp"]
         # We can't remove af_xdp in such case, so let's remove transparent
         # slice
         for i in range(len(part)):


### PR DESCRIPTION
This part should always be ignored for af_xdp_strict mode, regardless of whether af_xdp or af_xdp_no_filters options are present or not.

OL-Redmine-Id: 12768
Fixes: 0be5da288ae9 ("Sapi-TS going public")
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

-----
Checked with the following command line (with this patch the transparent part disappears):
```shell
$ ./scripts/gen_onload_part.py -a 3558 375 my-cfg master --use-params-file=<path-to-gen-onload-parts.yml> -x
transparent;;IP_TRANSPARENT,!IP6_ONLOAD;pkt_nocomp,hwport2,epoll3,scalable_any,no_rx_ts,bond4,vlan,ipvlan,no_reuse_pco,phys_mode,fw_full_featured,tcp_shared_ports_reuse_fast,tcp_shared_ports,default_pselect,fds_mt_safe,epoll_mt_safe,tcp_no_delack,loop4,disable_timestamps,fdtable_strict,socket_cache,urg_ignore,mcast_send1,scalable,onload 
cache_testing;tcp,level5/fd_caching;FD_CACHING,!IP6_ONLOAD;pkt_nocomp,hwport2,epoll3,no_rx_ts,bond4,vlan,ipvlan,no_reuse_pco,phys_mode,fw_full_featured,tcp_shared_ports_reuse_fast,tcp_shared_ports,default_pselect,fds_mt_safe,epoll_mt_safe,tcp_no_delack,loop4,disable_timestamps,fdtable_strict,socket_cache,af_xdp,zc_af_xdp,urg_ignore,mcast_send1,onload
```