### PR TITLE
scripts: disable tiny-spin if run with af_xdp

### DIFF
--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -544,6 +544,11 @@ function af_xdp_fix()
                     "$info/SWNETLINUX-4809/Bug 11986: disable netns on SFC NICs with zc_af_xdp"
             fi
         fi
+
+        if ool_contains "tiny_spin" ; then
+                ool_remove "tiny_spin" \
+                    "$info/Bug 12656: disable tiny_spin with af_xdp"
+        fi
     else
         # zc_af_xdp should be used only with AF_XDP
         ool_remove "zc_af_xdp" \


### PR DESCRIPTION
tiny-spin mode has been added to simulate a customer who is essentially interested in the low lattency
(High Frequency Trading). AF_XDP doesn't provide
good latency results thus the set af_xdp + tiny_spin has no sense.

OL-Redmine-Id: 12656
Signed-off-by: Pavel Liulchak <pavel.liulchak@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>


_____
Testing done:
cmd:
`./run.sh -n --cfg=${my_cfg} --tester-run=sockapi-ts/congestion/app_rtt%ee7e7425cf945916e1c19e9b0328b7dd --ool=onload --ool=af_xdp --log-html=html --sniff-log-conv-disable --ool=tiny_spin`
```
RING: af_xdp_fix/Bug 11802/ON-12446: using --ool=few_stacks
RING: af_xdp_fix/Bug 12656: disable tiny_spin with af_xdp: removing --ool=tiny_spin
...
--->>> Start Tester
Starting package sockapi-ts
Starting test prologue                                                             pass
Starting package congestion
Starting test prologue                                                             pass
Starting test app_rtt                                                              pass
Starting test epilogue                                                             pass
Done package congestion pass
Starting test epilogue                                                             pass
Done package sockapi-ts pass
```
proposed patch is part of https://github.com/oktetlabs/sapi-ts  
see [oktetlabs/sapi-ts@0f911da9](https://github.com/oktetlabs/sapi-ts/commit/0f911da9075c706793bf88e5841828cc0a23715c)