### PR TITLE
trc: fill in TRC for iomux_multicast:iomux=oo_epoll

### DIFF
--- a/trc/trc-sockapi-ts-multicast.xml
+++ b/trc/trc-sockapi-ts-multicast.xml
@@ -8358,7 +8358,7 @@
         <arg name="packet_number"/>
         <arg name="sock_func"/>
         <notes/>
-        <results tags="v5&amp;(ool_mcast_send=0|ool_mcast_send=2)" key="ST-2511">
+        <results tags="v5&amp;reuse_stack&amp;(ool_mcast_send=0|ool_mcast_send=2)" key="ST-2511">
           <result value="FAILED"/>
         </results>
       </iter>


### PR DESCRIPTION
The TRC tag reuse_stack should be used for iomux=oo_epoll iterations, just as it is used for the rest of the iterations of iomux.

OL-Redmine-Id: 11929
Signed-off-by: Georgii Samoilov <georgii.samoilov@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

--------
The following command line is green now:
```shell
./run.sh -n --cfg=<my-cfg> --tester-run=sockapi-ts/multicast/iomux_multicast:env=VAR.env.peer2peer_mcast_lo,iomux=oo_epoll --ool=mcast_send2 --ool=onload
```