### PR TITLE
reuseport_threaded_iomux: add parameter late_iomux and fill-in TRC for the test

### DIFF
--- a/sockapi-ts/reuseport/package.xml
+++ b/sockapi-ts/reuseport/package.xml
@@ -277,6 +277,38 @@
                 <value>4</value>
               </arg>
               <arg name="iomux" type="iomux"/>
+              <arg name="late_iomux" type="boolean">
+                <value>FALSE</value>
+              </arg>
+              <arg name="same_tst" type="boolean" list="">
+                <value>FALSE</value>
+                <value>FALSE</value>
+                <value>TRUE</value>
+              </arg>
+              <arg name="same_port" type="boolean" list="">
+                <value>FALSE</value>
+                <value>TRUE</value>
+                <value>TRUE</value>
+              </arg>
+            </run>
+
+            <run>
+              <script name="reuseport_threaded_iomux" track_conf="silent">
+                <req id="OOL1502"/>
+              </script>
+              <arg name="env">
+                <value ref="env.two_nets.iut_first"/>
+              </arg>
+              <arg name="listeners_num">
+                <value>4</value>
+              </arg>
+              <arg name="iomux" type="iomux">
+                <value>epoll</value>
+                <value>epoll_pwait</value>
+              </arg>
+              <arg name="late_iomux" type="boolean">
+                <value>TRUE</value>
+              </arg>
               <arg name="same_tst" type="boolean" list="">
                 <value>FALSE</value>
                 <value>FALSE</value>
@@ -869,6 +901,9 @@
                 <value>4</value>
               </arg>
               <arg name="iomux" type="iomux"/>
+              <arg name="late_iomux" type="boolean">
+                <value>FALSE</value>
+              </arg>
               <arg name="same_tst" type="boolean" list="">
                 <value>FALSE</value>
                 <value>FALSE</value>

--- a/trc/trc-sockapi-ts-reuseport.xml
+++ b/trc/trc-sockapi-ts-reuseport.xml
@@ -419,13 +419,113 @@
       <notes/>
       <iter result="PASSED">
         <arg name="env"/>
-        <arg name="scalable_filters_enable"/>
+        <arg name="scalable_filters_enable">0</arg>
         <arg name="iomux"/>
         <arg name="late_iomux"/>
         <arg name="listeners_num"/>
         <arg name="same_port"/>
         <arg name="same_tst"/>
         <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">1</arg>
+        <arg name="iomux"/>
+        <arg name="late_iomux"/>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">select</arg>
+        <arg name="late_iomux"/>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">pselect</arg>
+        <arg name="late_iomux"/>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">poll</arg>
+        <arg name="late_iomux"/>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">ppoll</arg>
+        <arg name="late_iomux"/>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+        <notes/>
+      </iter>
+      <iter result="FAILED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">epoll</arg>
+        <arg name="late_iomux">FALSE</arg>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+        <notes/>
+        <results tags="v5" key="12054">
+          <result value="FAILED">
+            <verdict>Unable to bind two listener sockets on the same stack</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="FAILED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">epoll_pwait</arg>
+        <arg name="late_iomux">FALSE</arg>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+      <notes/>
+        <results tags="v5" key="12054">
+          <result value="FAILED">
+            <verdict>Unable to bind two listener sockets on the same stack</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">epoll</arg>
+        <arg name="late_iomux">TRUE</arg>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+      <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="scalable_filters_enable">2</arg>
+        <arg name="iomux">epoll_pwait</arg>
+        <arg name="late_iomux">TRUE</arg>
+        <arg name="listeners_num"/>
+        <arg name="same_port"/>
+        <arg name="same_tst"/>
+      <notes/>
       </iter>
     </test>
     <test name="reuseport_rcvtimeo" type="script">

--- a/trc/trc-sockapi-ts-reuseport.xml
+++ b/trc/trc-sockapi-ts-reuseport.xml
@@ -421,6 +421,7 @@
         <arg name="env"/>
         <arg name="scalable_filters_enable"/>
         <arg name="iomux"/>
+        <arg name="late_iomux"/>
         <arg name="listeners_num"/>
         <arg name="same_port"/>
         <arg name="same_tst"/>


### PR DESCRIPTION
Checked with the following command line:
```shell
./run.sh -n --cfg=<my-cfg> --ool=onload --ool=scalable_iut --ool=scalable_active_passive \
--ool=no_reuse_pco --tester-run=sockapi-ts/reuseport/reuseport_threaded_iomux
```