### PR TITLE
checksum: add IPv6 iterations

### DIFF
--- a/sockapi-ts/checksum/package.xml
+++ b/sockapi-ts/checksum/package.xml
@@ -17,12 +17,15 @@
 
         <run>
             <session>
-                <arg name="env">
+                <arg name="env" list="env_proto_pairs">
                     <value ref="env.peer2peer"/>
+                    <value ref="env.peer2peer"/>
+                    <value ref="env.peer2peer_ipv6"/>
                 </arg>
                 <arg name="csum_val" type="checksum_val_type"/>
-                <arg name="protocol">
+                <arg name="protocol" list="env_proto_pairs">
                     <value>IPPROTO_IP</value>
+                    <value>IPPROTO_TCP</value>
                     <value>IPPROTO_TCP</value>
                 </arg>
 

--- a/sockapi-ts/checksum/tcp_bad_csum_close.c
+++ b/sockapi-ts/checksum/tcp_bad_csum_close.c
@@ -13,6 +13,7 @@
  *
  * @param env      Testing environment:
  *      - @ref arg_types_env_peer2peer
+ *      - @ref arg_types_env_peer2peer_ipv6
  * @param segment  What segment to send with invalid checksum:
  *      - FIN
  *      - RST

--- a/sockapi-ts/checksum/tcp_bad_csum_open.c
+++ b/sockapi-ts/checksum/tcp_bad_csum_open.c
@@ -13,6 +13,7 @@
  *
  * @param env      Testing environment:
  *      - @ref arg_types_env_peer2peer
+ *      - @ref arg_types_env_peer2peer_ipv6
  * @param segment  What segment to send with invalid checksum:
  *      - SYN
  *      - SYNACK


### PR DESCRIPTION
New parameter value env = env_peer2peer_ipv6 for the tests tcp_bad_csum_close, tcp_bad_csum_conn, tcp_bad_csum_open. Now these tests also have iterations with IPv6 sockets.

In these iterations the parameter 'protocol' is only IPPROTO_TCP, because IPv6 header does not contain checksum

Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>