### PR TITLE
scripts: avoid netns testing on SFC NICs with zc_af_xdp

### DIFF
--- a/scripts/ool_fix_reqs.py
+++ b/scripts/ool_fix_reqs.py
@@ -11,10 +11,14 @@ parser = argparse.ArgumentParser(
                 'of necessary tester requirements.')
 parser.add_argument("--ools", required=True, type=str,
                     help="Set of OOL options")
+parser.add_argument("--iut_drv", required=True, type=str,
+                    help="Driver name")
+
 args = parser.parse_args()
 
 ools_str = args.ools
 ools = ools_str.split(" ")
+iut_drv = args.iut_drv
 reqs = ""
 
 def ring(msg: str = "") -> None:

--- a/scripts/ool_fix_reqs.py
+++ b/scripts/ool_fix_reqs.py
@@ -126,4 +126,12 @@ add_req("!ONLOAD_ZC_SEND_USER_BUF",
 add_req("!ONLOAD_ZC_HLRX",
         "ON-14302: onload_zc_hlrx_recv_zc() is broken")
 
+# netns + zc_af_xdp parameter combination
+# on sfc crashes further testing, see SWNETLINUX-4809/Bug-11986.
+if iut_drv in ["sfc"]:
+    if "zc_af_xdp" in ools:
+        add_req("!NETNS",
+        "SWNETLINUX-4809/Bug-11986: do not test network namespaces of "
+        "SFC NICs with zc_af_xdp")
+
 print(reqs)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -285,7 +285,7 @@ if [[ "$TE_TS_BUILD_ONLY" != "yes" ]] ; then
     iut_drv="$(get_cfg_env ${cfg} TE_ENV_IUT_NET_DRIVER)"
     iut_dut="$(get_cfg_env ${cfg} TE_ENV_IUT_DUT)"
     OOL_SET=$(${RUNDIR}/scripts/ool_fix_consistency.sh "$iut_drv" "$iut_dut" $OOL_SET)
-    AUX_REQS=$(${RUNDIR}/scripts/ool_fix_reqs.py --ools="$OOL_SET")
+    AUX_REQS=$(${RUNDIR}/scripts/ool_fix_reqs.py --ools="$OOL_SET" --iut_drv="$iut_drv")
     RUN_OPTS="${RUN_OPTS} ${AUX_REQS}"
 
     RUN_OPTS="$RUN_OPTS $OOL_PROFILE"


### PR DESCRIPTION
`sockapi-ts/route/if_change_netns` is test that uses NETNS requirement and mey crash further runs.

cmd: `./run.sh -q --cfg=host-sfc --tester-run=sockapi-ts/route/if_change_netns --ool=onload --ool=af_xdp --ool=zc_af_xdp --ool=netns_all --log-html=html`

OpenOnload: `54958ab61230c2624a3ffa329fa8aba06d5061c2`
ts-conf:    `b882465e07f7ef510d1df2ca673efa81a49f62d9`
Open TE:    `96847d49d06b0c37092b18950873a40074b8d96f`

logs:
```
RING: af_xdp_fix/SWNETLINUX-4809/Bug 11986: disable netns on SFC NICs with zc_af_xdp: removing --ool=netns_all
...
RING: req_fix: SWNETLINUX-4809/Bug-11986: do not test network namespaces of SFC NICs with zc_af_xdp: adding --tester-req=!NETNS
...
--->>> Starting Logger...done
--->>> Starting RCF...done
--->>> Starting Configurator...done
--->>> Start Tester
--->>> Shutdown Configurator...done
--->>> Flush Logs
--->>> Shutdown RCF...done
--->>> Shutdown Logger...done
--->>> Logs conversion...done

Run (total)                               0
  Passed, as expected                     0
  Failed, as expected                     0
  Passed unexpectedly                     0
  Failed unexpectedly                     0
  Aborted (no useful result)              0
  New (expected result is not known)      0
Not Run (total)                       10920
  Skipped, as expected                    0
  Skipped unexpectedly                    0
```
The test is avoided as intended.

The proposed patches are part of https://github.com/oktetlabs/sapi-ts
see https://github.com/oktetlabs/sapi-ts/commit/c799b486c5a5b6bc43d7ff5ff3d9b43f894774c7
see https://github.com/oktetlabs/sapi-ts/commit/0e65736a06eb91ef451e2471b956708265841d21