### PR TITLE
scripts: disable vlan if test af_xdp over vlan on Intel/Mellanox

### DIFF
--- a/scripts/gen_onload_part.py
+++ b/scripts/gen_onload_part.py
@@ -118,19 +118,12 @@ def fix_testing_parms(host, ools, reqs, sl, slice_name,
     if older_then(branch, "onload-8.0"):
         remove_silent(ools, "af_xdp_no_filters", "af_xdp", "zc_af_xdp")
 
-    # Remove ipvlan and macvlan before checking netns_iut + bond
+    # Remove ipvlan and macvlan if they are not allowed in the host
     if host in params["no_ipvlan"]:
         remove_silent(ools, "ipvlan")
     if host in params["no_vlan_macvlan"]:
         if "vlan" in ools and "macvlan" in ools:
             remove_silent(ools, "macvlan")
-
-    if "netns_iut" in ools and not is_pattern_in_list(ools, "vlan") and \
-       is_pattern_in_list(ools, "bond", "team"):
-        for i in range(len(ools)):
-            if "bond" in ools[i] or "team" in ools[i]:
-                ools.insert(i + 1, "vlan")
-                break
 
     # ST-1567 comment 10
     if "scalable_active_passive" in ools and "no_reuse_pco" not in ools:

--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -526,6 +526,22 @@ function ipvlan_fix()
     fi
 }
 
+function aggregation_fix()
+{
+    local info="aggregation_fix"
+
+    if ool_contains "aggregation" || ool_contains "team*" || ool_contains "bond*" ; then
+        # aggregation interface + netns_iut has to be tested with either
+        # macvlan/ipvlan or vlan
+        if ool_contains "netns_iut" && ! ool_contains "*vlan"; then
+            # The ordering is important, netns should be after
+            # team/bond and after macvlan/ipvlan/vlan;
+            ool_put_before "vlan" "netns_iut" \
+                "$info: aggregation + netns_iut should be tested at least with (mac/ip)vlan"
+        fi
+    fi
+}
+
 # All AF_XDP limitations can be found in ON-12141
 # Must be called before scalable_fix.
 function af_xdp_fix()
@@ -640,6 +656,7 @@ zf_shim_fix
 syscall_fix
 ef100soc_fix
 build_ulhelper_fix
+aggregation_fix
 af_xdp_fix
 # socket_cache_fix should be before scalable_fix
 socket_cache_fix

--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -13,6 +13,37 @@ fail() {
     exit 1
 }
 
+#######################################
+# Checks whether the 'input_set' contains the 'value' item.
+# Globals:
+#   None
+# Arguments:
+#   value       - what to search, can be a pattern
+#   input_set   - where to search the 'value'
+# Return:
+#   0 if the 'value' is found, 1 otherwise
+#######################################
+is_value_in_set() {
+    local value="$1" ; shift
+    local input_set="$@"
+    local it=
+
+    if [[ -z "$value" ]] ; then
+        fail "is_value_in_set(): value argument cannot be empty"
+    fi
+
+    if [[ -z "$input_set" ]] ; then
+        fail "is_value_in_set(): input_set argument cannot be empty"
+    fi
+
+    for it in $input_set ; do
+        if [[ "$it" == $value ]] ; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 #
 # Checks whether the 'ool_set' contains the 'value' item
 #
@@ -26,18 +57,12 @@ fail() {
 #
 ool_contains() {
     local value="$1" ; shift
-    local it=
 
     if [[ -z "$value" ]] ; then
         fail "ool_contains(): value cannot be empty"
     fi
 
-    for it in $ool_set ; do
-        if [[ "$it" == $value ]] ; then
-            return 0
-        fi
-    done
-    return 1
+    is_value_in_set "$value" "$ool_set"
 }
 
 #


### PR DESCRIPTION
Runs were performed on revisions:
OpenOnload: `54958ab61230c2624a3ffa329fa8aba06d5061c2`
ts-conf: `b882465e07f7ef510d1df2ca673efa81a49f62d9`
Open-TE: `96847d49d06b0c37092b18950873a40074b8d96f`


1) **WITHOUT** the [3rd patch](https://github.com/Xilinx-CNS/cns-sapi-ts/commit/d5883639c7308622d48156b8edf457ee25a15614) we get a failure:
cmd: `./run.sh -q --cfg=$intel_cfg --tester-run=sockapi-ts/usecases/send_recv:env=VAR.env.peer2peer,sock_func=onload_socket_unicast_nonaccel*10 --tester-run-while=expected --ool=vlan --ool=af_xdp --ool=onload --log-html=html`

logs:
```
--->>> Start Tester                                                                                                                                                                           
Starting package sockapi-ts                                                                                                                                                                   
Starting test prologue                                                                                                                                                             pass       
Starting package usecases                                                                                                                                                                     
Starting test send_recv                                                                                                                                                            FAILED
Done package usecases FAILED                                                                                                                                                                  
Starting test epilogue                                                                                                                                                             pass       
Done package sockapi-ts FAILED                                                                                                                                                                
```

2) With the patch all works fine:
cmd: `./run.sh -q --cfg=$intel_cfg --tester-run=sockapi-ts/usecases/send_recv:env=VAR.env.peer2peer,sock_func=onload_socket_unicast_nonaccel*10 --tester-run-while=expected --ool=vlan --ool=af_xdp --ool=onload --log-html=html`

logs:
```
RING: af_xdp_fix/Bug 11959: avoid vlan in onload + af_xdp + vlan testing on Intel/Mellanox: removing --ool=vlan
...
--->>> Start Tester
Starting package sockapi-ts
Starting test prologue                                                                                                                                                             pass
Starting package usecases                                                                                                                                                                     
Starting test send_recv                                                                                                                                                            pass       
...
Done package usecases pass
Starting test epilogue                                                                                                                                                             pass
Done package sockapi-ts pass
```

3) `aggr + netns_iut` should be tested at least with `vlan`, `macvlan` or `ipvlan`. We have accounted for this fact:
cmd: `./run.sh -n --cfg=$intel_cfg --tester-run=sockapi-ts/usecases/send_recv:env=VAR.env.peer2peer,sock_func=onload_socket_unicast_nonaccel*40 --tester-run-while=expected --ool=bond4 --ool=vlan --ool=netns_iut --ool=af_xdp --ool=onload --log-html=html`

We can't delete `vlan` option in case of `aggr + netns_iut` and can't keep it without either `macvlan` or `ipvlan` thus we replace `vlan` on `macvlan`. All works.
logs:
```
RING: af_xdp_fix/Bug 11959: avoid vlan in onload + af_xdp + vlan testing on Intel/Mellanox: replacing --ool=vlan with --ool=macvlan
...
--->>> Start Tester                                                                                                                                                                           
Starting package sockapi-ts                                                                                                                                                                   
Starting test prologue                                                                                                                                                             pass       
Starting package usecases                                                                                                                                                                     
Starting test send_recv                                                                                                                                                            pass       
...
Starting test send_recv                                                                                                                                                            pass
Done package usecases pass
Starting test epilogue                                                                                                                                                             pass
```

The patches is part of https://github.com/oktetlabs/sapi-ts
see https://github.com/oktetlabs/sapi-ts/commit/c0036039beefb41af8a3318218907a32eef9bb77 and https://github.com/oktetlabs/sapi-ts/commit/fc4f5ed08ea4d0c928fed8b740b44a772a77efa8
see https://github.com/oktetlabs/sapi-ts/commit/a273bb5c56e49583541f5585ca003a84f0757899
see https://github.com/oktetlabs/sapi-ts/commit/cd6939d7eb099438fccd0beb0a84f16a59cf8447