### PR TITLE
prologue: consider an empty interface name as its absence

### DIFF
--- a/sockapi-ts/prologue.c
+++ b/sockapi-ts/prologue.c
@@ -181,7 +181,7 @@ configure_nfqueue_tst(rcf_rpc_server *pco)
     if (ifname_1 != NULL)
         ifname_2 = getenv("TE_TST1_IUT_IUT");
 
-    if (ifname_2 != NULL)
+    if (!te_str_is_null_or_empty(ifname_2))
     {
         CHECK_RC(tapi_cfg_iptables_chain_add(pco->ta, ifname_2, "mangle",
                                              "NFQ_B", FALSE));


### PR DESCRIPTION
Otherwise, the test may try to change the iptables rules on a non-existent interface.

OL-Redmine-Id: 12871
Signed-off-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---------
The following command line is green now:
```shell
./run.sh -n --cfg=<my-host-with-single-interface> --tester-run=sockapi-ts/usecases/read_write --ool=ip_options
```