### PR TITLE
tcp/tcp_server_restart: remove SO_REUSEPORT

### DIFF
--- a/sockapi-ts/doc/sapi_tests.yml
+++ b/sockapi-ts/doc/sapi_tests.yml
@@ -3292,6 +3292,9 @@ groups:
     - test: tcp_loopback
       summary: Testing of TCP connection between sockets on the same host
 
+    - test: tcp_server_restart
+      summary: Test which simulates TCP server restart
+
     - test: tcp_small_segment
       summary: Small segment receiving
 

--- a/sockapi-ts/lib/sockapi-ts_tcp.h
+++ b/sockapi-ts/lib/sockapi-ts_tcp.h
@@ -355,6 +355,27 @@ extern void sockts_shutdown_check_tcp_state(rcf_rpc_server *pco_iut,
 extern te_errno sockts_check_tcp_conn_csap(rcf_rpc_server *rpcs, int s,
                                            tapi_tcp_handler_t csap_s);
 
+/**
+ * Try to connect to IUT, making many attempts with 1 second intervals
+ * between them
+ *
+ * @param rpcs               RPC server
+ * @param sock               Socket
+ * @param iut_addr           Host address to connect it
+ * @param wait_accept_min_s  If rpc_connect() failed, its next calls should
+ *                           fail again until this number of seconds;
+ *                           or @c -1, in which case this is not checked
+ * @param wait_accept_max_s  If rpc_connect() failed, its next call should
+ *                           succeed before this number of seconds;
+ *                           or @c -1, in which case this is not checked
+ *
+ * @return Status code.
+ */
+extern te_errno sockts_connect_retry(rcf_rpc_server *rpcs, int sock,
+                                     const struct sockaddr *iut_addr,
+                                     int wait_accept_min_s,
+                                     int wait_accept_max_s);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/sockapi-ts/tcp/meson.build
+++ b/sockapi-ts/tcp/meson.build
@@ -67,6 +67,7 @@ tests = [
     'tcp_handle_syn',
     'tcp_last_data',
     'tcp_loopback',
+    'tcp_server_restart',
     'tcp_small_segment',
     'tcp_small_window',
     'tcp_state_hang',

--- a/sockapi-ts/tcp/package.dox
+++ b/sockapi-ts/tcp/package.dox
@@ -72,6 +72,7 @@ TCP packets, etc.
 -# @ref tcp-ack_out_of_window
 -# @ref tcp-ts_send
 -# @ref tcp-rst_send_partial
+-# @ref tcp-tcp_server_restart
 
 @}
 

--- a/sockapi-ts/tcp/package.xml
+++ b/sockapi-ts/tcp/package.xml
@@ -785,6 +785,39 @@
         </run>
 
         <run>
+            <script name="tcp_server_restart">
+                <req id="SOCK_STREAM"/>
+                <req id="SO_REUSEADDR"/>
+            </script>
+            <arg name="env">
+                <value ref="env.peer2peer"/>
+                <value ref="env.peer2peer_ipv6"/>
+            </arg>
+            <arg name="accepted_num" list="">
+                <value>200</value>
+                <value>200</value>
+                <value>833</value>
+                <value>833</value>
+            </arg>
+            <arg name="time_wait_num" list="">
+                <value>0</value>
+                <value>7</value>
+                <value>442</value>
+                <value>111</value>
+            </arg>
+            <arg name="closed_num" list="">
+                <!-- all old connections were closed -->
+                <value>200</value>
+                <!-- all are closed, some of them are in TIME_WAIT state -->
+                <value>193</value>
+                <!-- many sockets in TIME_WAIT, few are alive -->
+                <value>321</value>
+                <!-- many sockets are alive -->
+                <value>511</value>
+            </arg>
+        </run>
+
+        <run>
             <script name="syn_recv_fin_wait1" track_conf="silent">
                 <req id="SOCK_STREAM"/>
             </script>

--- a/sockapi-ts/tcp/tcp_server_restart.c
+++ b/sockapi-ts/tcp/tcp_server_restart.c
@@ -1,0 +1,164 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2023 Advanced Micro Devices, Inc. */
+/*
+ * Socket API Test Suite
+ * TCP
+ */
+
+/** @page tcp-tcp_server_restart Test which simulates TCP server restart
+ *
+ * @objective Accept many TCP connections, create new RPC server, accept a
+ *            new connection there, check it, check unclosed connections on
+ *            the original RPC server.
+ *
+ * @param env             Testing environment:
+ *                        - @ref arg_types_env_peer2peer
+ *                        - @ref arg_types_env_peer2peer_ipv6
+ * @param accepted_num    Number of accepted connections
+ * @param time_wait_num   Number of connections to call close on
+ * @param closed_num      Number of connections to close
+ *
+ * @par Scenario:
+ *
+ * @author Boris Shleyfman <bshleyfman@oktet.co.il>
+ */
+
+#define TE_TEST_NAME  "tcp/tcp_server_restart"
+
+#include "sockapi-test.h"
+
+#define WAIT_ACCEPT_MIN_S   30
+#define WAIT_ACCEPT_MAX_S   120
+
+#define CONNECT_AND_ACCEPT(_pco_tst, _pco_iut, _tst_s, _iut_s,          \
+                           _iut_addr, _accept_s)                        \
+    do {                                                                \
+        _tst_s = rpc_socket(_pco_tst,                                   \
+                            rpc_socket_domain_by_addr(_iut_addr),       \
+                            RPC_SOCK_STREAM, RPC_PROTO_DEF);            \
+        if (sockts_connect_retry(_pco_tst, _tst_s, _iut_addr,           \
+                                 WAIT_ACCEPT_MIN_S,                     \
+                                 WAIT_ACCEPT_MAX_S) != 0)               \
+        {                                                               \
+            RPC_CLOSE(_pco_tst, _tst_s);                                \
+            RPC_CLOSE(_pco_iut, _iut_s);                                \
+            TEST_STOP;                                                  \
+        }                                                               \
+        _accept_s = rpc_accept(_pco_iut, _iut_s, NULL, NULL);           \
+    } while(0)
+
+int
+main(int argc, char *argv[])
+{
+    rcf_rpc_server        *pco_iut = NULL;
+    rcf_rpc_server        *pco_tst = NULL;
+    rcf_rpc_server        *pco_iut_new = NULL;
+    const struct sockaddr *iut_addr;
+    int                    accepted_num;
+    int                    time_wait_num;
+    int                    closed_num;
+
+    int  iut_s = -1;
+    int  tst_s = -1;
+    int  iut_new_s = -1;
+    int  accept_s = -1;
+    int  i;
+    int *accepted_ss = NULL;
+    int *connected_ss = NULL;
+
+    TEST_START;
+    TEST_GET_PCO(pco_iut);
+    TEST_GET_PCO(pco_tst);
+    /* Find a free port and set iut_addr to IUT's IP address */
+    TEST_GET_ADDR(pco_iut, iut_addr);
+    TEST_GET_INT_PARAM(accepted_num);
+    TEST_GET_INT_PARAM(time_wait_num);
+    TEST_GET_INT_PARAM(closed_num);
+
+    accepted_ss = TE_ALLOC(accepted_num * sizeof(int));
+    connected_ss = TE_ALLOC(accepted_num * sizeof(int));
+
+    TEST_STEP("Create listening socket.");
+    iut_s = rpc_socket(pco_iut, rpc_socket_domain_by_addr(iut_addr),
+                       RPC_SOCK_STREAM, RPC_PROTO_DEF);
+    rpc_setsockopt_int(pco_iut, iut_s, RPC_SO_REUSEADDR, 1);
+    rpc_bind(pco_iut, iut_s, iut_addr);
+    rpc_listen(pco_iut, iut_s, SOCKTS_BACKLOG_DEF);
+
+    TEST_STEP("Accept @p accepted_num connections.");
+    for (i = 0; i < accepted_num; i++)
+    {
+        CONNECT_AND_ACCEPT(pco_tst, pco_iut, tst_s, iut_s, iut_addr,
+                           accept_s);
+        connected_ss[i] = tst_s;
+        accepted_ss[i] = accept_s;
+    }
+
+    TEST_STEP("Close @p time_wait_num of accepted sockets on IUT to achieve"
+              " TIME_WAIT state.");
+    for (i = 0; i < time_wait_num; i++)
+    {
+        RPC_CLOSE(pco_iut, accepted_ss[i]);
+        TAPI_WAIT_NETWORK;
+        RPC_CLOSE(pco_tst, connected_ss[i]);
+    }
+
+    TEST_STEP("Close @p closed_num of connected sockets on Tester to"
+              " achieve CLOSED state.");
+    for (i = time_wait_num;
+         i < time_wait_num + closed_num && i < accepted_num;
+         i++)
+    {
+        RPC_CLOSE(pco_tst, connected_ss[i]);
+        TAPI_WAIT_NETWORK;
+        RPC_CLOSE(pco_iut, accepted_ss[i]);
+    }
+
+    TEST_STEP("Close listening socket.");
+    RPC_CLOSE(pco_iut, iut_s);
+
+    TEST_STEP("Create new RPC server.");
+    CHECK_RC(rcf_rpc_server_create(pco_iut->ta, "iut_new", &pco_iut_new));
+
+    TEST_STEP("Create a listening socket on the new RPC server using the"
+              " port that was used on the original IUT RPC server.");
+    iut_new_s = rpc_socket(pco_iut_new, rpc_socket_domain_by_addr(iut_addr),
+                           RPC_SOCK_STREAM, RPC_PROTO_DEF);
+    rpc_setsockopt_int(pco_iut_new, iut_new_s, RPC_SO_REUSEADDR, 1);
+    rpc_bind(pco_iut_new, iut_new_s, iut_addr);
+    rpc_listen(pco_iut_new, iut_new_s, SOCKTS_BACKLOG_DEF);
+
+    TEST_STEP("Accept connection on the new RPC server and verify its"
+              " connectivity.");
+    CONNECT_AND_ACCEPT(pco_tst, pco_iut_new, tst_s, iut_new_s, iut_addr,
+                       accept_s);
+    sockts_test_connection(pco_iut_new, accept_s, pco_tst, tst_s);
+
+    TEST_STEP("Check the connectivity of unclosed connections on the"
+              " original IUT RPC server.");
+    for (i = time_wait_num + closed_num; i < accepted_num; i++)
+    {
+        sockts_test_connection(pco_iut, accepted_ss[i], pco_tst,
+                               connected_ss[i]);
+    }
+
+    TEST_SUCCESS;
+
+cleanup:
+    for (i = 0; i < accepted_num; i++)
+    {
+        CLEANUP_RPC_CLOSE(pco_iut, accepted_ss[i]);
+        CLEANUP_RPC_CLOSE(pco_tst, connected_ss[i]);
+    }
+    CLEANUP_RPC_CLOSE(pco_iut_new, accept_s);
+    CLEANUP_RPC_CLOSE(pco_iut, iut_s);
+    CLEANUP_RPC_CLOSE(pco_tst, tst_s);
+    CLEANUP_RPC_CLOSE(pco_iut_new, iut_new_s);
+    if (pco_iut_new != NULL)
+    {
+        CHECK_RC(rcf_rpc_server_destroy(pco_iut_new));
+    }
+    free(accepted_ss);
+    free(connected_ss);
+    TEST_END;
+}

--- a/trc/trc-sockapi-ts-tcp.xml
+++ b/trc/trc-sockapi-ts-tcp.xml
@@ -5428,6 +5428,17 @@
         </results>
       </iter>
     </test>
+    <test name="tcp_server_restart" type="script">
+      <objective>Create many TCP connections, restart RPC server, accept and check a new connection, check not closed connections.</objective>
+      <notes/>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="accepted_num"/>
+        <arg name="time_wait_num"/>
+        <arg name="closed_num"/>
+        <notes/>
+      </iter>
+    </test>
     <test name="tcp_zero_window_ext" type="script">
       <objective>Check that TCP socket closes properly despite it received a packet with the zero window.</objective>
       <notes/>


### PR DESCRIPTION
Remove unnecessary use of SO_REUSEPORT from the test. Using socket option SO_REUSEADDR is enough to bind socket with the same address and port.

AMD-Jira-Id: ST-2697

Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>