### PR TITLE
tcp/tcp_server_restart: remove SO_REUSEPORT

### DIFF
--- a/sockapi-ts/tcp/package.xml
+++ b/sockapi-ts/tcp/package.xml
@@ -787,7 +787,6 @@
         <run>
             <script name="tcp_server_restart">
                 <req id="SOCK_STREAM"/>
-                <req id="SO_REUSEPORT"/>
                 <req id="SO_REUSEADDR"/>
             </script>
             <arg name="env">

--- a/sockapi-ts/tcp/tcp_server_restart.c
+++ b/sockapi-ts/tcp/tcp_server_restart.c
@@ -125,7 +125,6 @@ main(int argc, char *argv[])
     iut_new_s = rpc_socket(pco_iut_new, rpc_socket_domain_by_addr(iut_addr),
                            RPC_SOCK_STREAM, RPC_PROTO_DEF);
     rpc_setsockopt_int(pco_iut_new, iut_new_s, RPC_SO_REUSEADDR, 1);
-    rpc_setsockopt_int(pco_iut_new, iut_new_s, RPC_SO_REUSEPORT, 1);
     rpc_bind(pco_iut_new, iut_new_s, iut_addr);
     rpc_listen(pco_iut_new, iut_new_s, SOCKTS_BACKLOG_DEF);
 


### PR DESCRIPTION
Remove unnecessary use of SO_REUSEPORT from the test. Using socket option SO_REUSEADDR is enough to bind socket with the same address and port.

AMD-Jira-Id: ST-2697

Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>