### PR TITLE
tcp/tcp_server_restart: use proper library for IUT pco

### DIFF
--- a/sockapi-ts/tcp/tcp_server_restart.c
+++ b/sockapi-ts/tcp/tcp_server_restart.c
@@ -119,6 +119,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Create new RPC server.");
     CHECK_RC(rcf_rpc_server_create(pco_iut->ta, "iut_new", &pco_iut_new));
+    CHECK_RC(rcf_rpc_setlibname(pco_iut_new, pco_iut->nv_lib));
 
     TEST_STEP("Create a listening socket on the new RPC server using the"
               " port that was used on the original IUT RPC server.");


### PR DESCRIPTION
Setup IUT library name for the second listen socket, because the default one is not what we need by the scenario.

https://github.com/oktetlabs/sapi-ts/commit/8da1ab91eccda8bae23f63433a008372fe958ff7