### PR TITLE
talib: fix executable stack kernel warning

### DIFF
--- a/talib_sockapi_ts/syscall_close.S
+++ b/talib_sockapi_ts/syscall_close.S
@@ -10,6 +10,13 @@
  * $Id$
  */
 
+/* By default, assembler code starts process with executable stack.
+ * This line switches to non-executable stack.
+ * See
+ * https://lore.kernel.org/lkml/20191208171918.GC19716@avx2/
+ */
+.section .note.GNU-stack,"",@progbits
+
 #ifdef __CYGWIN__
 #undef __unix__
 #endif


### PR DESCRIPTION
By default, assembler code in talib leads to process start with executable stack. Modify assembler code to avoid this issue.

OL-Redmine-Id: 12841

Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---

Testing done:
Open TE: `736841be0cded9f0a98aaef784f81fe887ff6549`
Open Onload: `da11323a6402a2b2392768b619bf2689490b5457`

Before the patch executable stack kernel warning occurred on each first test agent start after host reboot:
```
...
[  616.511803] onload_cp_server[1845]: Accelerating enp2s0f1: RX 2 TX 2
[  825.938888] ICMPv6: process `ta' is using deprecated sysctl (syscall) net.ipv6.neigh.enp2s0f0.retrans_time - use net.ipv6.neigh.enp2s0f0.retrans_time_ms instead
[  854.448843] process '/ta_ubuntu22_kuzandro_734165_1688489031_4/ta_rpcs' started with executable stack

[forced to `spy' mode by tester@localhost]
...
``` 
This happened because of assembler code in talib. Added special `.section` to assembler code to start with non-executable stack.
Reproducer example (run on `${my_host}` after reboot):
`./run.sh -q --cfg=${my_host} --tester-run=sockapi-ts/usecases/send_recv --ool=onload --log-html=html`
After the patch the warning doesn't appear:
```
...
[ 1152.136557] onload_cp_server[1839]: Accelerating enp2s0f1: RX 2 TX 2
[ 1152.847719] IPv6: ADDRCONF(NETDEV_CHANGE): enp2s0f1: link becomes ready
[ 1216.182441] ICMPv6: process `ta' is using deprecated sysctl (syscall) net.ipv6.neigh.enp2s0f0.retrans_time - use net.ipv6.neigh.enp2s0f0.retrans_time_ms instead

[forced to `spy' mode by tester@localhost]
...
```