### PR TITLE
level5/out_of_resources: fix allocate_stack event failure

### DIFF
--- a/sockapi-ts/level5/out_of_resources/out_of_stacks.c
+++ b/sockapi-ts/level5/out_of_resources/out_of_stacks.c
@@ -82,13 +82,24 @@ main(int argc, char *argv[])
     TEST_GET_ADDR(pco_tst, tst_addr);
     TEST_GET_BOOL_PARAM(ef_no_fail);
 
-    /* Turn off allocate_stack parser */
-    CHECK_RC(cfg_get_instance_fmt(NULL, &pars_signal,
-                                  "/local:/tester:/event:allocate_stack"
-                                  "/handler:internal_handler/signal:"));
-    CHECK_RC(cfg_set_instance_fmt(CVT_STRING, "none",
-                                  "/local:/tester:/event:allocate_stack"
-                                  "/handler:internal_handler/signal:"));
+    /*
+     * Turn off allocate_stack parser if allocate_stack log event
+     * is turned on
+     */
+    rc = (cfg_get_instance_fmt(NULL, &pars_signal,
+                               "/local:/tester:/event:allocate_stack"
+                               "/handler:internal_handler/signal:"));
+    if (rc == 0)
+    {
+        CHECK_RC(cfg_set_instance_fmt(CVT_STRING, "none",
+                                      "/local:/tester:/event:allocate_stack"
+                                      "/handler:internal_handler/signal:"));
+    }
+    else if (TE_RC_GET_ERROR(rc) != TE_ENOENT)
+    {
+        TEST_FAIL("Test could not access Configurator to get allocate_stack"
+                  " event handler");
+    }
 
     memset(child, 0, sizeof(child));
     for (i = 0; i < MAX_SOCKS; i++)


### PR DESCRIPTION
Do not fail on absense of allocate_stack event in the Configurator database while running level5/out_of_resources/out_of_stacks test, because this event may be turned off.

OL-Redmine-Id: 12903

Reviewed-by: Sergey Nikitin <sergey.nikitin@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>
___
Testing done:
Open TE: 1bddac291cbcdb32e3254972ded82ec9a75f1d39
Open Onload: b8998ae559b576616edfa251e4678f30e132514d

If `log_event_allocate_stack` is turned off, the test fails with error:
```
Test Failed in ../../../sapi-ts/sockapi-ts/level5/out_of_resources/out_of_stacks.c, line 86, main() 
line 86: cfg_get_instance_fmt(NULL, &pars_signal, "/local:/tester:/event:allocate_stack" "/handler:internal_handler/signal:") returns 0xF400002 (CS-ENOENT), but expected 0 
```
In this patch `CS-ENOENT` for getting `event:allocate_stack` instance is handled in a different way to fix the failure.