### PR TITLE
usecases/splice: fix acc_pipe=FALSE iterations

### DIFF
--- a/sockapi-ts/usecases/splice.c
+++ b/sockapi-ts/usecases/splice.c
@@ -155,7 +155,7 @@ main(int argc, char *argv[])
     TEST_STEP("Disable pipe acceleration on @p pco_iut according to "
               "@p acc_pipe parameter");
     if (!acc_pipe)
-        CHECK_RC(tapi_sh_env_unset(pco_iut, "EF_PIPE", TRUE, TRUE));
+        CHECK_RC(tapi_sh_env_set(pco_iut, "EF_PIPE", "0", TRUE, TRUE));
 
     if (overfill_pipe)
         CHECK_RC(rcf_rpc_server_thread_create(pco_iut, "iut_thread",


### PR DESCRIPTION
Really disable pipe acceleration by setting EF_PIPE env variable to zero. Simple unsetting the variable is not enough.


Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>

---
I checked the patch on Debian-testing with `6.4.0-1-amd64`.
Command line for socket-tester:
```
--tester-run=sockapi-ts/usecases/splice:splice_before_data=FALSE,set_move=FALSE,set_nonblock=FALSE,extra_pipes=0,overfill_pipe=FALSE,acc_pipe=FALSE,diff_stacks=FALSE,pipe_size=unchanged --ool=onload --ool=af_xdp
```
P.S.: so many parameters is to reduce number of iterations.

There're few unexpected results, because  `splice()` returns `EINVAL` on some iterations.