### PR TITLE
lib: allow not to specify rpcs_ns during netns creation

### DIFF
--- a/sockapi-ts/lib/sockapi-ts.c
+++ b/sockapi-ts/lib/sockapi-ts.c
@@ -3645,7 +3645,6 @@ sockts_netns_setup_common(const char *ta_name, const char *host,
     CHECK_NOT_NULL(netns);
     CHECK_NOT_NULL(netns_ta);
     CHECK_NOT_NULL(netns_rpcs);
-    CHECK_NOT_NULL(rpcs_ns);
 
     CHECK_RC(tapi_netns_add(ta_name, netns));
     CHECK_RC(tapi_netns_if_set(ta_name, netns, recv_veth2_name));

--- a/sockapi-ts/lib/sockapi-ts.h
+++ b/sockapi-ts/lib/sockapi-ts.h
@@ -4070,7 +4070,7 @@ extern void sockts_find_parent_if(rcf_rpc_server *rpcs,
  * @param netns_ta              Name of the created Test Agent.
  * @param netns_rpcs            Name of the created RPC server.
  * @param rcf_port              Port number.
- * @param rpcs_ns               Location for netns RPC server.
+ * @param rpcs_ns               Location for netns RPC server or @c NULL.
  * @param ns_addr               Location for allocated address.
  * @param addr_handle           Location for allocated address configuration
  *                              handle.


### PR DESCRIPTION
In function sockts_netns_setup_common() in lib/sockapi-ts.c, do not
check that parameter rpcs_ns is not NULL. Specifying a location for
RPC server handle is not required for the server creation. Ignoring
this broke the congestion package.

Fixes: 0f89596c0ddb ("congestion/lib: update function for netns creation on TST")
Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>
