### PR TITLE
conf: handle absence of ignored headers

### DIFF
--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -239,7 +239,18 @@ for header in extensions.h extensions_zc.h extensions_timestamping.h extensions_
     if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
         local_file="${SFC_ONLOAD_EXT_HEADERS}/${header}"
         target="${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/copied_headers/${header}"
-        rsync_from "$TE_IUT" "$local_file" "$target"
+        for ignored_header in "${IGNORED_ONLOAD_HEADERS[@]}"; do
+            if [[ "${header}" == "${ignored_header}" ]]; then
+                HEADER_IS_IGNORED="yes"
+                break
+            fi
+        done
+        if [[ "${HEADER_IS_IGNORED}" == "yes" ]]; then
+            echo "INFO: file $header does not exist"
+        else
+            rsync_from "$TE_IUT" "$local_file" "$target"
+        fi
+        HEADER_IS_IGNORED=
     else
         target="${SFC_ONLOAD_EXT_HEADERS}/${header}"
     fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -232,10 +232,6 @@ if test "${ZF_SHIM_RUN}" = "true" ; then
     check_sf_zetaferno_dir $OOL_SET
 fi
 
-if test -n "${TE_TS_SOCKAPI}" ; then
-    RUN_OPTS="${RUN_OPTS} --opts=opts.ts"
-fi
-
 if test "${ST_IP_TRANSPARENT}" = "yes" ; then
     RUN_OPTS="${RUN_OPTS} --tester-req=\"ENV-IUT-FAKE-ADDR\""
     # Scalable filters are not supported with AF_XDP. ST-2231.
@@ -299,6 +295,10 @@ if [[ "$TE_TS_BUILD_ONLY" != "yes" ]] ; then
             RUN_OPTS="$RUN_OPTS --script=ool/config/$i"
         fi
     done
+fi
+
+if test -n "${TE_TS_SOCKAPI}" ; then
+    RUN_OPTS="${RUN_OPTS} --opts=opts.ts"
 fi
 
 eval "${TE_BASE}/dispatcher.sh ${MY_OPTS} ${RUN_OPTS}"


### PR DESCRIPTION
Write a comment in the output about ignored headers absence instead of
rsync error.

OL-Redmine-Id: 13098

Reviewed-by: Alexandra Kossovsky <alexandra.kossovsky@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

---

Testing done:
Open TE: 036933085164a20bff7c5d3d21980c196e270b1c
Open Onload: 76e6c7d6d2720a3e62a2bde3502d8bbf87dcd8c3

Different branches may contain different set of extension headers. Absence of headers causes rsync errors:
```
rsync: [sender] link_stat "/home/ol-kuzandro/my_branch/src/include/onload/extensions_zc_hlrx.h" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1819) [Receiver=3.2.3]
rsync: [Receiver] write error: Broken pipe (32)
```
To handle these errors with comments `IGNORED_ONLOAD_HEADERS` array can be exported. Without ignored headers run works the same way.