### PR TITLE
scripts: copy branch specific headers set last

### DIFF
--- a/conf/scripts/copy-onload-headers
+++ b/conf/scripts/copy-onload-headers
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# (c) Copyright 2023 OKTET Labs Ltd., 2004 - 2022 Xilinx, Inc. All rights reserved.
+
+# Copy/create symlinks for the set of Onload headers, specific for currently
+# used branch
+for header in extensions.h extensions_zc.h extensions_timestamping.h\
+    extensions_zc_hlrx.h test_intf.h; do
+    dst_name="${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/${header}"
+    if [[ "$SFC_ONLOAD_LOCAL" == "yes" ]]; then
+        local_file="${SFC_ONLOAD_EXT_HEADERS}/${header}"
+        target="${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/copied_headers/${header}"
+        for ignored_header in "${IGNORED_ONLOAD_HEADERS[@]}"; do
+            if [[ "${header}" == "${ignored_header}" ]]; then
+                HEADER_IS_IGNORED="yes"
+                break
+            fi
+        done
+        if [[ "${HEADER_IS_IGNORED}" == "yes" ]]; then
+            echo "INFO: file $header does not exist"
+        else
+            rsync_from "$TE_IUT" "$local_file" "$target"
+        fi
+        HEADER_IS_IGNORED=
+    else
+        target="${SFC_ONLOAD_EXT_HEADERS}/${header}"
+    fi
+    if test -f "$target"; then
+        ln_sf_safe "$target" "$dst_name"
+    fi
+done

--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# (c) Copyright 2004 - 2022 Xilinx, Inc. All rights reserved.
+# (c) Copyright 2023 OKTET Labs Ltd., 2004 - 2022 Xilinx, Inc. All rights reserved.
 #
 # The file contains sockapi-ts specific environments processing and
 # configuration.
@@ -233,31 +233,6 @@ fi
 if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
     mkdir -p "${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/copied_headers"
 fi
-for header in extensions.h extensions_zc.h extensions_timestamping.h extensions_zc_hlrx.h\
-    test_intf.h ; do
-    dst_name="${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/${header}"
-    if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
-        local_file="${SFC_ONLOAD_EXT_HEADERS}/${header}"
-        target="${SOCKAPI_TS_LIBDIR}/talib_sockapi_ts/copied_headers/${header}"
-        for ignored_header in "${IGNORED_ONLOAD_HEADERS[@]}"; do
-            if [[ "${header}" == "${ignored_header}" ]]; then
-                HEADER_IS_IGNORED="yes"
-                break
-            fi
-        done
-        if [[ "${HEADER_IS_IGNORED}" == "yes" ]]; then
-            echo "INFO: file $header does not exist"
-        else
-            rsync_from "$TE_IUT" "$local_file" "$target"
-        fi
-        HEADER_IS_IGNORED=
-    else
-        target="${SFC_ONLOAD_EXT_HEADERS}/${header}"
-    fi
-    if test -f "$target"; then
-        ln_sf_safe "$target" "$dst_name"
-    fi
-done
 
 if test "x$SFC_ONLOAD_LOCAL" == "xyes" ; then
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -232,6 +232,10 @@ if test "${ZF_SHIM_RUN}" = "true" ; then
     check_sf_zetaferno_dir $OOL_SET
 fi
 
+if test -n "${TE_TS_SOCKAPI}" ; then
+    RUN_OPTS="${RUN_OPTS} --opts=opts.ts"
+fi
+
 if test "${ST_IP_TRANSPARENT}" = "yes" ; then
     RUN_OPTS="${RUN_OPTS} --tester-req=\"ENV-IUT-FAKE-ADDR\""
     # Scalable filters are not supported with AF_XDP. ST-2231.
@@ -297,8 +301,8 @@ if [[ "$TE_TS_BUILD_ONLY" != "yes" ]] ; then
     done
 fi
 
-if test -n "${TE_TS_SOCKAPI}" ; then
-    RUN_OPTS="${RUN_OPTS} --opts=opts.ts"
+if test -n "${TE_TS_SOCKAPI}"; then
+    RUN_OPTS="$RUN_OPTS --script=scripts/copy-onload-headers"
 fi
 
 eval "${TE_BASE}/dispatcher.sh ${MY_OPTS} ${RUN_OPTS}"


### PR DESCRIPTION
Copy the set of headers, specific for currently used branch, or create symlinks for them in the script run last.

Run other sockapi configurations before the scripts fixing ool consistency as further executed scripts need exports from sockapi configurations.

Fixes: d74da290255c ("scripts: run sockapi configuration scripts last")
OL-Redmine-Id: 13098

Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

---

Testing done:
Open TE: 036933085164a20bff7c5d3d21980c196e270b1c
Open Onload: 76e6c7d6d2720a3e62a2bde3502d8bbf87dcd8c3

Executing all the scripts from `opts.ts` last has broken bonding, teaming and onload-profile testing.
Reproducer command line:
```
./run.sh --cfg=${my_host_conf} -q --cs-print-trees --cs-log-diff --tester-ignore-run-name \
--trc-log=trc-log.bz2 --trc-tag=no-aio --trc-tag=no-aio-dgram --ool=pkt_nohuge --ool=hwport2 \
--ool=udp_connect_no_handover --ool=epoll3 --ool=iomux_no_fast --ool=no_rx_ts --ool=team1 \
--ool=macvlan --ool=no_reuse_pco --ool=scooby --ool=default_poll --ool=epoll_mt_safe \
--ool=tcp_no_delack --ool=loop1 --ool=oo_single_if --ool=fdtable_strict --ool=socket_cache \
--ool=zc_reg_huge_align --ool=urg_ignore --ool=mcast_send3 --ool=onload --ool=cplane_track_xdp \
--ool=reuse_stack --ool=tcp_shared_ports --ool=loop_onload --ool=cplane_log_to_kernel \
--ool=defaults --tester-req=V5_SANITY '--tester-req=!IP6_ONLOAD' '--tester-req=!AIO' \
'--tester-req=!SF_BLACKLIST' '--tester-req=!BROKEN' --log-junit=log.junit --trc-txt=trc-stats.txt \
--no-tester
```

To fix this issue `opts.ts` was returned to it's initial place in ools list, and only the part of configurations where rsync errors used to occur were moved to a separate script executed last.

With this fix bonding, teaming and onload-profile testing work together with rsync error handling.
