### PR TITLE
sockapi-ts: correctly complete operations in cleanup section

### DIFF
--- a/sockapi-ts/bnbvalue/file_max_overflow.c
+++ b/sockapi-ts/bnbvalue/file_max_overflow.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* (c) Copyright 2004 - 2022 Xilinx, Inc. All rights reserved. */
+/* (c) Copyright 2023 OKTET Labs Ltd. */
 /*
  * Socket API Test Suite
  * Bad Parameters and Boundary Values
@@ -237,7 +238,7 @@ cleanup:
     {
         /* Restart to rollback user ID. */
         CLEANUP_CHECK_RC(rcf_rpc_server_restart(pco_iut));
-        CHECK_RC(tapi_cfg_del_user(pco_iut->ta, SOCKTS_DEF_UID));
+        CLEANUP_CHECK_RC(tapi_cfg_del_user(pco_iut->ta, SOCKTS_DEF_UID));
     }
 
     /* Timeout needed because Onload can close FD for too long.

--- a/sockapi-ts/tcp/tcp_loopback.c
+++ b/sockapi-ts/tcp/tcp_loopback.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* (c) Copyright 2004 - 2022 Xilinx, Inc. All rights reserved. */
+/* (c) Copyright 2023 OKTET Labs Ltd. */
 /* 
  * Socket API Test Suite
  * Basic Socket API
@@ -502,7 +503,7 @@ cleanup:
     {
         /* Restart to rollback user ID. */
         CLEANUP_CHECK_RC(rcf_rpc_server_restart(pco_tst));
-        CHECK_RC(tapi_cfg_del_user(pco_tst->ta, SOCKTS_DEF_UID));
+        CLEANUP_CHECK_RC(tapi_cfg_del_user(pco_tst->ta, SOCKTS_DEF_UID));
     }
 
     /* This test changes environment variables and does not roll them back.


### PR DESCRIPTION
In the cleanup section the CLEANUP_CHECK_RC macro should be used instead of CHECK_RC.

Fixes: 0be5da288ae9 ("Sapi-TS going public")

-------------
Rebuild is OK.