### PR TITLE
tcp/fin_data: make sure that CSAP really started

### DIFF
--- a/sockapi-ts/tcp/fin_data.c
+++ b/sockapi-ts/tcp/fin_data.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* (c) Copyright 2004 - 2022 Xilinx, Inc. All rights reserved. */
+/* (c) Copyright 2023 OKTET Labs Ltd. */
 /* 
  * Socket API Test Suite
  * TCP tests
@@ -92,6 +93,7 @@ main(int argc, char *argv[])
     TEST_STEP("Start CSAP sniffer to track transmitetd packets.");
     CHECK_RC(tapi_tad_trrecv_start(pco_gw->ta, 0, csap, NULL,
                                    TAD_TIMEOUT_INF, 0, RCF_TRRECV_PACKETS));
+    TAPI_WAIT_NETWORK;
 
     TEST_STEP("Send data packet from IUT.");
     RPC_SEND(rc, pco_iut, iut_s, sndbuf, length, 0);


### PR DESCRIPTION
Give the CSAP time to run before continuing with the testing steps.

OL-Redmine-Id: 13265


----------
The following command line is green now:
```shell
./run.sh --no-builder --cfg=<hostname> \
--tester-run=sockapi-ts/tcp/fin_data:cache_socket=FALSE,env=VAR.env.peer2peer_gw,linger=TRUE,shutdown=FALSE*100 \
--tester-run-while=expected --ool=hwport2 --ool=udp_connect_no_handover --ool=epoll3 --ool=iomux_no_fast --ool=sleep_spin \
--ool=syscall --ool=no_rx_ts --ool=no_reuse_pco --ool=scooby --ool=tcp_shared_ports_reuse_fast --ool=tcp_shared_ports \
--ool=default_poll --ool=loop1 --ool=safe_epoll3 --ool=fdtable_strict --ool=socket_cache --ool=af_xdp_no_filters \
--ool=zc_af_xdp --ool=tcp_combine_send --ool=zc_reg_huge_align --ool=urg_ignore --ool=mcast_send1 --ool=onload \
--ool=reuse_stack --ool=loop_onload --ool=spin --ool=cplane_log_to_kernel --ool=epoll_ctl_fast --ool=defaults
```