### PR TITLE
sockapi-ts/lib: do not fail if the user already exists

### DIFF
--- a/sockapi-ts/bnbvalue/file_max_overflow.c
+++ b/sockapi-ts/bnbvalue/file_max_overflow.c
@@ -151,7 +151,8 @@ main(int argc, char *argv[])
         TEST_STEP("If @p other_user is @c TRUE, create a new user on IUT "
                   "and use @b setuid() on @p pco_iut to switch to it.");
 
-        CHECK_RC(tapi_cfg_add_new_user(pco_iut->ta, SOCKTS_DEF_UID));
+        CHECK_RC(tapi_cfg_add_user_if_needed(pco_iut->ta, SOCKTS_DEF_UID,
+                                             NULL));
         rpc_setuid(pco_iut, SOCKTS_DEF_UID);
     }
 

--- a/sockapi-ts/lib/sockapi-ts.h
+++ b/sockapi-ts/lib/sockapi-ts.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* (c) Copyright 2004 - 2022 Xilinx, Inc. All rights reserved. */
+/* (c) Copyright 2023 OKTET Labs Ltd. */
 /** @file
  * @brief Socket API Test Suite
  *
@@ -3955,7 +3956,7 @@ sockts_server_change_uid(rcf_rpc_server *rpcs)
 {
     tarpc_uid_t     uid = 0;
 
-    CHECK_RC(tapi_cfg_add_new_user(rpcs->ta, SOCKTS_DEF_UID));
+    CHECK_RC(tapi_cfg_add_user_if_needed(rpcs->ta, SOCKTS_DEF_UID, NULL));
     rpc_setuid(rpcs, SOCKTS_DEF_UID);
     uid = rpc_getuid(rpcs);
     if (uid != SOCKTS_DEF_UID)

--- a/sockapi-ts/tcp/tcp_loopback.c
+++ b/sockapi-ts/tcp/tcp_loopback.c
@@ -287,7 +287,8 @@ main(int argc, char *argv[])
             break;
 
         case DIFF_USERS:
-            CHECK_RC(tapi_cfg_add_new_user(pco_iut->ta, SOCKTS_DEF_UID));
+            CHECK_RC(tapi_cfg_add_user_if_needed(pco_iut->ta, SOCKTS_DEF_UID,
+                                                 NULL));
             diff_user = TRUE;
             SET_CHECK_USER_BY_ID(pco_tst, SOCKTS_DEF_UID);
             SET_CHECK_USER_BY_ID(pco_iut, passwd->pw_uid);


### PR DESCRIPTION
There may be situations when a test tries to add a user who already exists on IUT: tests should not fail because of this.

------
The following tests are green now (on test-environment: [d461e193c](https://github.com/oktetlabs/test-environment/commit/d461e193c5b102beb42365ff04e16f5b761a2ea9)):
```console
./run.sh --no-builder --cfg=<host> \
--tester-run=sockapi-ts/basic/bind_sockaddr_send%9520b304c06ff9ff98c02196537a0147 \
--tester-run=sockapi-ts/bnbvalue/file_max_overflow:env=VAR.env.peer2peer,fd_type=tcp_passive,other_user=TRUE \
--tester-run=sockapi-ts/tcp/tcp_loopback%6c9511645b34f2279a6b70782b5784b7
```
