### PR TITLE
tcp/send_retrans_fail: add verdicts to TRC

### DIFF
--- a/sockapi-ts/tcp/send_retrans_fail.c
+++ b/sockapi-ts/tcp/send_retrans_fail.c
@@ -148,7 +148,12 @@ main(int argc, char *argv[])
 
     TEST_STEP("Send a TCP packet from IUT to TST using some send"
               " function.");
+    RPC_AWAIT_IUT_ERROR(pco_iut);
     n_bytes = send_func(pco_iut, iut_s, tx_buf, PAYLOAD_LEN, 0);
+    if (n_bytes < 0)
+    {
+        TEST_VERDICT("send_func() failed with errno %r", RPC_ERRNO(pco_iut));
+    }
     if (n_bytes != PAYLOAD_LEN)
     {
         WARN("%d bytes were sent, instead of %d", n_bytes, PAYLOAD_LEN);

--- a/trc/trc-sockapi-ts-tcp.xml
+++ b/trc/trc-sockapi-ts-tcp.xml
@@ -9113,8 +9113,136 @@
       <notes/>
       <iter result="PASSED">
         <arg name="env"/>
+        <arg name="send_func">write</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">writev</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">send</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">sendto</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">sendmsg</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">onload_zc_send</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">onload_zc_send_user_buf</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">template_send</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">od_send</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">od_send_raw</arg>
+        <arg name="retrans_fail_way">rto</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">write</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">writev</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">send</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">sendto</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">sendmsg</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">onload_zc_send</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">onload_zc_send_user_buf</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">template_send</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">od_send</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">od_send_raw</arg>
+        <arg name="retrans_fail_way">rst</arg>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">sendmmsg</arg>
+        <arg name="retrans_fail_way">rto</arg>
+        <notes/>
+        <results tags="v5" notes="sendmmsg() is not supported on TCP in Onload">
+          <result value="FAILED">
+            <verdict>send_func() failed with errno RPC-ENOSYS</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="send_func">sendmmsg</arg>
+        <arg name="retrans_fail_way">rst</arg>
+        <notes/>
+        <results tags="v5" notes="sendmmsg() is not supported on TCP in Onload">
+          <result value="FAILED">
+            <verdict>send_func() failed with errno RPC-ENOSYS</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
         <arg name="send_func"/>
-        <arg name="retrans_fail_way"/>
+        <arg name="retrans_fail_way">user_timeout</arg>
+        <notes/>
+        <results tags="v5" key="ON-2512">
+          <result value="FAILED">
+            <verdict>setsockopt() failed to enable TCP_USER_TIMEOUT, errno=RPC-ENOPROTOOPT</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>


### PR DESCRIPTION
Add two verdicts for the test to TRC: for retrans_fail_way=user_timeout
and for send_func=sendmmsg. They describe the expected behavior for the
test if it is run with Onload. In the test, print verdict in the case
of an error after calling send_func().

AMD-Jira-Id: ST-2535
Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
