### PR TITLE
tcp/send_retrans_fail: delete unused variable

### DIFF
--- a/sockapi-ts/tcp/send_retrans_fail.c
+++ b/sockapi-ts/tcp/send_retrans_fail.c
@@ -79,7 +79,6 @@ main(int argc, char *argv[])
     const struct if_nameindex *iut_if = NULL;
 
     const void                *alien_link_addr = NULL;
-    const char                *tcp_ca_state_seq;
 
     tsa_session               ss = TSA_SESSION_INITIALIZER;
 


### PR DESCRIPTION
Delete an unused variable, this caused a compilator warning.

Fixes: 806a2b792ba4 ("tcp/send_retrans_fail: implement new test")
AMD-Jira-Id: ST-2535
Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
