### PR TITLE
lib: fix network prefix getting in library function

### DIFF
--- a/sockapi-ts/lib/sockapi-ts.c
+++ b/sockapi-ts/lib/sockapi-ts.c
@@ -3751,9 +3751,16 @@ sockts_netns_setup_common(const char *ta_name, const char *host,
         CHECK_RC(tapi_cfg_alloc_net_addr(net_handle, addr_handle, ns_addr));
 
     /* Get network prefix */
-    CHECK_RC(cfg_get_oid_str(net_handle, &net_oid));
-    CHECK_RC(cfg_get_instance_fmt(&val_type, &net_prefix, "%s/prefix:",
-                                  net_oid));
+    if (net_handle != CFG_HANDLE_INVALID)
+    {
+        CHECK_RC(cfg_get_oid_str(net_handle, &net_oid));
+        CHECK_RC(cfg_get_instance_fmt(&val_type, &net_prefix, "%s/prefix:",
+                                      net_oid));
+    }
+    else
+    {
+        net_prefix = te_netaddr_get_bitsize(AF_INET);
+    }
 
     CHECK_RC(tapi_cfg_base_if_add_net_addr(netns_ta, recv_veth2_name, *ns_addr,
                                            net_prefix, FALSE, NULL));


### PR DESCRIPTION
In function sockts_netns_setup_common() in lib/sockapi-ts, use network
prefix based on AF_INET address family if no network handle is passed.
This fixes an error in congestion/prologue.

Fixes: d93e0db6ac25 ("lib: fix network prefix getting in library function")
Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>
