### PR TITLE
scripts: turn off IF_DOWN_UP in case of sfc/i40e

### DIFF
--- a/scripts/ool_fix_reqs.py
+++ b/scripts/ool_fix_reqs.py
@@ -128,6 +128,13 @@ add_req("!ONLOAD_ZC_SEND_USER_BUF",
 add_req("!ONLOAD_ZC_HLRX",
         "ON-14302: onload_zc_hlrx_recv_zc() is broken")
 
+# af_xdp + zc_af_xdp parameter combinations
+# on sfc/i40e crash further testing, see Bug-12053.
+if iut_drv in ["sfc", "i40e"]:
+    if "zc_af_xdp" in ools:
+        add_req("!IF_DOWN_UP",
+        "Bug-12053: sfc and i40e do not restore XDP state after down-up")
+
 # netns + zc_af_xdp parameter combination
 # on sfc crashes further testing, see SWNETLINUX-4809/Bug-11986.
 if iut_drv in ["sfc"]:


### PR DESCRIPTION
sfc and i40e drivers do not restore XDP state after down-up thus test with af_xdp + zc_af_xdp parameter combinations on intel/sfc configurations fail and crash further testing. We avoid tests with mentioned parameters and IF_DOWN_UP req on i40e and sfc via setting !IF_DOWN_UP req.

OL-Redmine-Id: 12053

-------
Tested with the following command line:
```console
$ ./scripts/ool_fix_reqs.py --ools zc_af_xdp --iut_drv sfc
RING: req_fix: socket caching is disabled: adding --tester-req=!FD_CACHING
RING: req_fix: there are no any scalable filters: adding --tester-req=!SCALABLE
RING: req_fix: the use_chk_funcs option is not specified: adding --tester-req=!CHK_FUNC
RING: req_fix: ON-13696: onload_zc_send() with registered ZC buffer is broken: adding --tester-req=!ONLOAD_ZC_SEND_USER_BUF
RING: req_fix: ON-14302: onload_zc_hlrx_recv_zc() is broken: adding --tester-req=!ONLOAD_ZC_HLRX
RING: req_fix: Bug-12053: sfc and i40e do not restore XDP state after down-up: adding --tester-req=!IF_DOWN_UP
RING: req_fix: SWNETLINUX-4809/Bug-11986: do not test network namespaces of SFC NICs with zc_af_xdp: adding --tester-req=!NETNS
 --tester-req=!FD_CACHING --tester-req=!SCALABLE --tester-req=!CHK_FUNC --tester-req=!ONLOAD_ZC_SEND_USER_BUF --tester-req=!ONLOAD_ZC_HLRX --tester-req=!IF_DOWN_UP --tester-req=!NETNS
```