### PR TITLE
This is a set of minor changes in tests related to timeouts and the addition of a missed multicast tester-requirement.

### DIFF
--- a/sockapi-ts/arp/permanent_entry_untouched_by_request.c
+++ b/sockapi-ts/arp/permanent_entry_untouched_by_request.c
@@ -142,6 +142,8 @@ main(int argc, char *argv[])
                      0,
                      eth_filter_handle2);
 
+    TAPI_WAIT_NETWORK;
+
     TEST_STEP("Send some data from IUT socket.");
     if (sock_type == SOCKTS_SOCK_UDP_NOTCONN)
         RPC_SENDTO(rc, pco_iut, iut_s, tx_buf, buf_len, 0, tst_addr);

--- a/sockapi-ts/route/package.xml
+++ b/sockapi-ts/route/package.xml
@@ -1211,7 +1211,7 @@
                 <value>udp_connect</value>
             </arg>
             <arg name="multicast" type="boolean">
-                <value>TRUE</value>
+                <value reqs="MULTICAST">TRUE</value>
             </arg>
         </run>
 

--- a/sockapi-ts/sockopts/tcp_info_retransmits.c
+++ b/sockapi-ts/sockopts/tcp_info_retransmits.c
@@ -159,7 +159,16 @@ main(int argc, char *argv[])
     TEST_STEP("Send some data from IUT socket and check tcpi_info fields");
     RPC_SEND(rc, pco_iut, iut_s, tx_buf, data_buf_len, 0);
 
-    TAPI_WAIT_NETWORK;
+    /*
+     * `tcp_early_retrans` is not counted as a real retransmit,
+     * so we see 1 early retransmit after rto, then a real retransmit
+     * after another rto, and it this point it is counted and rto is
+     * doubled.  So we wait for 3*rto and expect tcpi_retransmits=1,
+     * tcpi_rto to be doubled.
+     */
+    RING("Sleeping %d * 3 = %d usec, catching retransmit after %d usec",
+         rto_first, rto_first * 3, rto_first);
+    usleep(rto_first * 3);
 
     check_fields(pco_iut, iut_s, tcpi_fields, tcpi_fields_num, FALSE,
                  &rto_first, FALSE, "After connectivity break");

--- a/sockapi-ts/tcp/send_retrans_fail.c
+++ b/sockapi-ts/tcp/send_retrans_fail.c
@@ -121,9 +121,9 @@ main(int argc, char *argv[])
     CHECK_RC(tsa_iut_set(&ss, pco_iut, iut_if, iut_addr));
     CHECK_RC(tsa_tst_set(&ss, pco_tst, tst_if, tst_addr,
                          ((struct sockaddr *)alien_link_addr)->sa_data));
-    CFG_WAIT_CHANGES;
 
     CHECK_RC(tsa_create_session(&ss, 0));
+    CFG_WAIT_CHANGES;
 
     TEST_STEP("Emulate an established TCP connection between IUT and TST.");
     tcp_move_to_state(&ss, RPC_TCP_ESTABLISHED, OL_ACTIVE, FALSE);


### PR DESCRIPTION
This is a set of minor changes in tests related to timeouts and the addition of a missed multicast tester-requirement.

-------------------
Testing done:
```console
./run.sh -n --cfg=<my-cfg> --tester-run-while=expected \
--tester-run=sockapi-ts/arp/permanent_entry_untouched_by_request:env=VAR.env.peer2peer,sock_type=udp_notconn*30

./scripts/run.sh -n --cfg=<my-cfg> --ool=onload --ool=af_xdp --tester-run-while=expected  \
--tester-run=sockapi-ts/sockopts/tcp_info_retransmits%d2ca282bf2781bb13e9f8672cf6b877a*10 

./run.sh -n --cfg=<my-cfg> --ool=onload --ool=no_reuse_pco \
--tester-run=sockapi-ts/tcp/send_retrans_fail:env=VAR.env.peer2peer,send_func=write,retrans_fail_way=rto*10 

./run.sh -n --cfg=<my-cfg> --tester-run=sockapi-ts/route/pbr_oif_src:multicast=TRUE --tester-req=\!MULTICAST
```