### PR TITLE
trc: fix TRC DB for ifcfg/recv_wrong_mac

### DIFF
--- a/trc/trc-sockapi-ts-ifcfg.xml
+++ b/trc/trc-sockapi-ts-ifcfg.xml
@@ -324,7 +324,8 @@
         <arg name="env"/>
         <arg name="sock_type">tcp_passive</arg>
         <notes/>
-        <results tags="v5&amp;ef10&amp;(!scalable_passive|rss_scalable_active_passive)" key="ON-3214">
+        <results tags="v5" key="ON-3214, Bug-12992" note="Accept any result regardless of the parameters">
+          <result value="PASSED"/>
           <result value="FAILED">
             <verdict>IUT socket is readable after receiving packet with a wrong Ethernet address</verdict>
           </result>
@@ -334,7 +335,8 @@
         <arg name="env"/>
         <arg name="sock_type">tcp_passive_close</arg>
         <notes/>
-        <results tags="v5&amp;ef10&amp;(!scalable_passive|rss_scalable_active_passive)" key="ON-3214">
+        <results tags="v5" key="ON-3214, Bug-12992" note="Accept any result regardless of the parameters">
+          <result value="PASSED"/>
           <result value="FAILED">
             <verdict>IUT socket is readable after receiving packet with a wrong Ethernet address</verdict>
           </result>
@@ -344,7 +346,8 @@
         <arg name="env"/>
         <arg name="sock_type">udp</arg>
         <notes/>
-        <results tags="v5&amp;ef10" key="ON-3214">
+        <results tags="v5" key="ON-3214, Bug-12992" note="Accept any result regardless of the parameters">
+          <result value="PASSED"/>
           <result value="FAILED">
             <verdict>IUT socket is readable after receiving packet with a wrong Ethernet address</verdict>
           </result>
@@ -354,7 +357,8 @@
         <arg name="env"/>
         <arg name="sock_type">tcp_active</arg>
         <notes/>
-        <results tags="v5&amp;ef10" key="ON-3214">
+        <results tags="v5" key="ON-3214, Bug-12992" note="Accept any result regardless of the parameters">
+          <result value="PASSED"/>
           <result value="FAILED">
             <verdict>IUT socket is readable after receiving packet with a wrong Ethernet address</verdict>
           </result>


### PR DESCRIPTION
Accept either of the two results regardless of the parameters. This is acceptable because if there is an unexpected verdict, the test will be red.

-------
The test is green now, I checked the following command lines:
```
./run.sh --n --cfg=<my-host> --tester-run=sockapi-ts/ifcfg/recv_wrong_mac --ool=onload --ool=af_xdp_no_filters
./run.sh --n --cfg=<my-host> --tester-run=sockapi-ts/ifcfg/recv_wrong_mac --ool=onload --ool=af_xdp
./run.sh --n --cfg=<my-host> --tester-run=sockapi-ts/ifcfg/recv_wrong_mac
```


