### PR TITLE
Set of improvements: update TRC DB for basic/listen_backlog_values and fix sleeping iomux/peer_close_before_accept

### DIFF
--- a/sockapi-ts/iomux/peer_close_before_accept.c
+++ b/sockapi-ts/iomux/peer_close_before_accept.c
@@ -158,7 +158,7 @@ main(int argc, char *argv[])
 
     rpc_closesocket(pco_aux, tst_s);
     tst_s = -1;
-    MSLEEP(100);
+    TAPI_WAIT_NETWORK;
 
     RPC_AWAIT_IUT_ERROR(pco_iut);
     accept_s = rpc_accept(pco_iut, iut_s, NULL, NULL);

--- a/trc/trc-sockapi-ts-basic.xml
+++ b/trc/trc-sockapi-ts-basic.xml
@@ -3667,94 +3667,15 @@
       <objective>Investigate treatment of listen() function backlog parameter.</objective>
       <notes/>
       <iter result="PASSED">
-        <arg name="backlog">0</arg>
+        <arg name="backlog"/>
         <arg name="env">VAR.env.peer2peer_lo_ipv6</arg>
         <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
-          <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
+        <results tags="linux" notes="Default Linux behavior">
           <result value="FAILED">
             <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
         </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing SF bug 75246">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">1</arg>
-        <arg name="env">VAR.env.peer2peer_lo_ipv6</arg>
-        <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
-          <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing SF bug 75246">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">10</arg>
-        <arg name="env">VAR.env.peer2peer_lo_ipv6</arg>
-        <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
-          <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing SF bug 75246">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">150</arg>
-        <arg name="env">VAR.env.peer2peer_lo_ipv6</arg>
-        <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
-          <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing SF bug 75246">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">-1</arg>
-        <arg name="env">VAR.env.peer2peer_lo_ipv6</arg>
-        <notes/>
-        <results tags="v5&amp;!(ool_loop=4&amp;!reuse_stack)" key="ON-8297">
+        <results tags="v5&amp;(ool_loop=2|ool_loop=3)" key="ON-4312">
           <result value="FAILED">
             <verdict>Measured backlog is more than expected</verdict>
           </result>
@@ -3767,103 +3688,17 @@
         </results>
       </iter>
       <iter result="PASSED">
-        <arg name="backlog">1</arg>
+        <arg name="backlog"/>
         <arg name="env">VAR.env.peer2peer_lo</arg>
         <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
-          <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
+        <results tags="linux" notes="Default Linux behavior">
           <result value="FAILED">
             <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
         </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing ON-8304">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">10</arg>
-        <arg name="env">VAR.env.peer2peer_lo</arg>
-        <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
+        <results tags="v5&amp;(ool_loop=2|ool_loop=3)" key="ON-4312">
           <result value="FAILED">
             <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing ON-8304">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">150</arg>
-        <arg name="env">VAR.env.peer2peer_lo</arg>
-        <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
-          <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing ON-8304">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">0</arg>
-        <arg name="env">VAR.env.peer2peer_lo</arg>
-        <notes/>
-        <results tags="v5&amp;((ool_loop=1|ool_loop=4)&amp;reuse_stack|ool_loop=2|ool_loop=3)" key="ON-4312">
-          <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=0" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-        <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing ON-8304">
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is more than expected</verdict>
-          </result>
-          <result value="FAILED">
-            <verdict>Measuring backlog: recv() failed with errno RPC-ECONNRESET</verdict>
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">-1</arg>
-        <arg name="env">VAR.env.peer2peer_lo</arg>
-        <notes/>
-        <results tags="v5&amp;!(ool_loop=4&amp;!reuse_stack)" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
         </results>
         <results tags="v5&amp;ool_loop=4&amp;!reuse_stack" key="ON-8297" notes="Verdict about ECONNRESET is expected after fixing ON-8304">
@@ -3877,37 +3712,67 @@
         <arg name="backlog">1</arg>
         <arg name="env">VAR.env.peer2peer</arg>
         <notes/>
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
+          <result value="FAILED">
+            <verdict>Measured backlog is a bit more than expected</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="backlog">10</arg>
         <arg name="env">VAR.env.peer2peer</arg>
         <notes/>
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
+          <result value="FAILED">
+            <verdict>Measured backlog is a bit more than expected</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="backlog">150</arg>
         <arg name="env">VAR.env.peer2peer</arg>
         <notes/>
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
+          <result value="FAILED">
+            <verdict>Measured backlog is a bit more than expected</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="backlog">1</arg>
         <arg name="env">VAR.env.peer2peer_ipv6</arg>
         <notes/>
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
+          <result value="FAILED">
+            <verdict>Measured backlog is a bit more than expected</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="backlog">10</arg>
         <arg name="env">VAR.env.peer2peer_ipv6</arg>
         <notes/>
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
+          <result value="FAILED">
+            <verdict>Measured backlog is a bit more than expected</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="backlog">150</arg>
         <arg name="env">VAR.env.peer2peer_ipv6</arg>
         <notes/>
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
+          <result value="FAILED">
+            <verdict>Measured backlog is a bit more than expected</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="backlog">0</arg>
         <arg name="env">VAR.env.peer2peer</arg>
         <notes/>
-        <results tags="v5" key="ON-8297">
+        <results tags="linux" notes="Default Linux behavior">
           <result value="FAILED">
             <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
@@ -3917,7 +3782,7 @@
         <arg name="backlog"/>
         <arg name="env">VAR.env.peer2peer_tst</arg>
         <notes/>
-        <results tags="v5" key="ON-8297">
+        <results tags="linux" notes="Default Linux behavior">
           <result value="FAILED">
             <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
@@ -3927,47 +3792,17 @@
         <arg name="backlog">0</arg>
         <arg name="env">VAR.env.peer2peer_ipv6</arg>
         <notes/>
-        <results tags="v5" key="ON-8297">
+        <results tags="linux" notes="Default Linux behavior">
           <result value="FAILED">
             <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
         </results>
       </iter>
       <iter result="PASSED">
-        <arg name="backlog">0</arg>
+        <arg name="backlog"/>
         <arg name="env">VAR.env.peer2peer_tst_ipv6</arg>
         <notes/>
-        <results tags="v5" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">1</arg>
-        <arg name="env">VAR.env.peer2peer_tst_ipv6</arg>
-        <notes/>
-        <results tags="v5" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">10</arg>
-        <arg name="env">VAR.env.peer2peer_tst_ipv6</arg>
-        <notes/>
-        <results tags="v5" key="ON-8297">
-          <result value="FAILED">
-            <verdict>Measured backlog is a bit more than expected</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">150</arg>
-        <arg name="env">VAR.env.peer2peer_tst_ipv6</arg>
-        <notes/>
-        <results tags="v5" key="ON-8297">
+        <results tags="linux" notes="Default Linux behavior">
           <result value="FAILED">
             <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
@@ -3977,24 +3812,19 @@
         <arg name="backlog">-1</arg>
         <arg name="env">VAR.env.peer2peer</arg>
         <notes/>
-      </iter>
-      <iter result="PASSED">
-        <arg name="backlog">-1</arg>
-        <arg name="env">VAR.env.peer2peer_ipv6</arg>
-        <notes/>
-        <results tags="v5" key="ON-8297">
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
           <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
+            <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
         </results>
       </iter>
       <iter result="PASSED">
         <arg name="backlog">-1</arg>
-        <arg name="env">VAR.env.peer2peer_tst_ipv6</arg>
+        <arg name="env">VAR.env.peer2peer_ipv6</arg>
         <notes/>
-        <results tags="v5" key="ON-8297">
+        <results tags="linux&amp;!v5" notes="Default Linux behavior">
           <result value="FAILED">
-            <verdict>Measured backlog is more than expected</verdict>
+            <verdict>Measured backlog is a bit more than expected</verdict>
           </result>
         </results>
       </iter>


### PR DESCRIPTION
The first commit is being checked by running the test on pure Linux and latest OpenOnload:
```console
./run.sh -n --cfg=<my-cfg> --tester-run=sockapi-ts/basic/listen_backlog_values
./run.sh -n --cfg=<my-cfg> --tester-run=sockapi-ts/basic/listen_backlog_values --ool=loop{0,1,2,3,4} --ool=onload
```

And the second one:
```console
./run.sh -n --cfg=<my-cfg> --ool=loop3 --ool=onload --tester-run-while=expected \
--tester-run=sockapi-ts/iomux/peer_close_before_accept%fe66ed4677cd943ad595a946b67de04c*100
```