### PR TITLE
Some improvements for basic/diff_ipvlan_macvlan_check and basic/diff_vlan_check_id tests

### DIFF
--- a/sockapi-ts/basic/diff_ipvlan_macvlan_check.c
+++ b/sockapi-ts/basic/diff_ipvlan_macvlan_check.c
@@ -428,7 +428,7 @@ main(int argc, char *argv[])
                        "{ arg-sets { simple-for:{begin 1,end %u} }, "
                        "  pdus  { udp:{},                           "
                        "          ip4:{                             "
-                       "                dst-addr plain:'%X'H        "
+                       "                dst-addr plain:'%08X'H      "
                        "              },                            "
                        "          eth:{}                            "
                        "        },                                  "

--- a/sockapi-ts/basic/package.xml
+++ b/sockapi-ts/basic/package.xml
@@ -3075,7 +3075,10 @@
                 <value ref="env.peer2peer"/>
             </arg>
             <arg name="use_macvlan" type="boolean"/>
-            <arg name="use_netns" type="boolean"/>
+            <arg name="use_netns" type="boolean">
+                <value>FALSE</value>
+                <value reqs="NETNS">TRUE</value>
+            </arg>
         </run>
 
         <run>
@@ -3089,7 +3092,10 @@
             <arg name="env">
                 <value ref="env.peer2peer"/>
             </arg>
-            <arg name="use_netns" type="boolean"/>
+            <arg name="use_netns" type="boolean">
+                <value>FALSE</value>
+                <value reqs="NETNS">TRUE</value>
+            </arg>
             <arg name="vlan1">
                 <value>999</value>
             </arg>


### PR DESCRIPTION
Some improvements for basic/diff_ipvlan_macvlan_check and basic/diff_vlan_check_id tests

Tested with the following command lines:
```
# netns
./run.sh -n --cfg=<my-cfg> --tester-req=\!NETNS \
--tester-run=sockapi-ts/basic/diff_ipvlan_macvlan_check:use_netns=TRUE \
--tester-run=sockapi-ts/basic/diff_vlan_check_id:use_netns=TRUE

# basic/diff_ipvlan_macvlan_check
./run.sh -n --cfg=<my-cfg> \
--tester-run=sockapi-ts/basic/diff_ipvlan_macvlan_check:use_netns=FALSE,use_macvlan=FALSE
```