### PR TITLE
basic: add IPv6 iterations to the VLAN tests

### DIFF
--- a/sockapi-ts/basic/package.xml
+++ b/sockapi-ts/basic/package.xml
@@ -3075,6 +3075,7 @@
             </script>
             <arg name="env">
                 <value ref="env.peer2peer"/>
+                <value ref="env.peer2peer_ipv6"/>
             </arg>
             <arg name="use_macvlan" type="boolean"/>
             <arg name="use_netns" type="boolean">
@@ -3093,6 +3094,7 @@
             </script>
             <arg name="env">
                 <value ref="env.peer2peer"/>
+                <value ref="env.peer2peer_ipv6"/>
             </arg>
             <arg name="use_netns" type="boolean">
                 <value>FALSE</value>


### PR DESCRIPTION
Add iterations with IPv6 env to the tests diff_vlan_check_id and
diff_ipvlan_macvlan_check.

Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
