### PR TITLE
trc: update TRC for ifcfg/if_remove_addr_after_many_conns

### DIFF
--- a/trc/trc-sockapi-ts-ifcfg.xml
+++ b/trc/trc-sockapi-ts-ifcfg.xml
@@ -180,6 +180,8 @@
           <result value="FAILED">
             <verdict>Socket 'acc_s[i]' is not expected to be readable, but it is</verdict>
           </result>
+          <!-- OL bug 11852: AF_XDP allows to receive packets to a removed IP address -->
+          <result value="PASSED"/>
         </results>
         <results tags="x3" key="ON-13769">
           <result value="FAILED">


### PR DESCRIPTION
Expect that iterations of the if_remove_addr_after_many_conns test can now succeed, this prevents test logs from being clogged with irrelevant results.

OL-Redmine-Id: 11852