### PR TITLE
Turn off many sockets + close + caching tests

### DIFF
--- a/sockapi-ts/basic/package.xml
+++ b/sockapi-ts/basic/package.xml
@@ -2287,6 +2287,10 @@
         <run>
             <script name="many_listen_connect_lo" track_conf="silent">
                 <req id="MEMORY_HOG"/>
+                <!-- There is no sense to test many sockets with socket caching,
+                     because close() does not release fds in presense of
+                     caching -->
+                <req id="FD_CACHE_INCOMPATIBLE"/>
             </script>
             <arg name="env">
                 <value ref="env.peer2peer_lo"/>

--- a/sockapi-ts/bnbvalue/package.xml
+++ b/sockapi-ts/bnbvalue/package.xml
@@ -195,13 +195,16 @@
                 </arg>
                 <arg name="retry" list="limit">
                     <value>-</value>
-                    <value>close</value>
+                    <!-- There is no sense to test many sockets with socket
+                         caching, because close() does not release fds in
+                         presense of caching -->
+                    <value reqs="FD_CACHE_INCOMPATIBLE">close</value>
                     <value>-</value>
                     <value reqs="BUG_45334">rlim</value>
-                    <value reqs="BUG_45334">close</value>
+                    <value reqs="BUG_45334,FD_CACHE_INCOMPATIBLE">close</value>
                     <value>-</value>
                     <value reqs="BUG_45334">rlim</value>
-                    <value reqs="BUG_45334">close</value>
+                    <value reqs="BUG_45334,FD_CACHE_INCOMPATIBLE">close</value>
                 </arg>
 
                 <run>


### PR DESCRIPTION
In too many sockets tests connections are being accepted until the
limit of opened file descriptors in the system is achieved (EMFILE
error). The last (not accepted) connection is saved in accept queue.
Tests close one of the accepted connections and accept the one saved
in the queue.

In case of socket caching, closing one of accepted connections does
not result in the freeing of accept queue and accept() still fails
with EMFILE error.

After Onload started to drop SYN in case of full accept queue, calling
connect() in this case started to result in timeout error. Tests with
many sockets and socket caching began to fail.

All in all, too many sockets tests does not make sense in case of
socket caching, because the accept queue is not freed. That is why this
combination should be turned off.

---

Checked with:
```
./run.sh --cfg=${my_host_conf} --tester-run=sockapi-ts/basic/many_listen_connect_lo \
--tester-run=sockapi-ts/bnbvalue/func_socket_pipe_too_many:retry=close --ool=socket_cache
```
Nothing is being run