### PR TITLE
small but useful changes to ./scripts

### DIFF
--- a/log.sh
+++ b/log.sh
@@ -4,4 +4,6 @@
 
 [ -e "./scripts/guess.sh" ] && source "./scripts/guess.sh"
 
-. $TE_BASE/scripts/log.sh --txt-timeout=300
+. $TE_BASE/scripts/guess.sh
+
+$TE_BASE/scripts/log.sh --txt-timeout=300 "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -228,6 +228,11 @@ export ST_IUT_IS_CMOD
 export L5_RUN=$L5_RUN
 export ZF_SHIM_RUN=$ZF_SHIM_RUN
 
+# TODO: remove this when sapi-ts stops relying on Jenkins
+# to generate metadata file. Until then this is needed
+# to avoid overwriting Jenkins metadata file by TE.
+RUN_OPTS="${RUN_OPTS} --no-meta"
+
 if test "${ZF_SHIM_RUN}" = "true" ; then
     check_sf_zetaferno_dir $OOL_SET
 fi


### PR DESCRIPTION
1. avoid overwriting metadata by TE (use --no-meta option by default)
2. scripts: improve logs generation

----------------
Tested by rebuild/run the sapi-ts.