### PR TITLE
The set of minor changes for tests and auxiliary scripts

### DIFF
--- a/scripts/ool_fix_consistency.sh
+++ b/scripts/ool_fix_consistency.sh
@@ -620,10 +620,12 @@ function af_xdp_fix()
         # Scalable filters are not supported
         ool_remove "scalable*" "$info: scalable filters are not supported"
 
-        if ool_contains "zc_af_xdp*" && ool_contains "netns_*" ; then
+        if ool_contains "zc_af_xdp*" ; then
             if [[ "$iut_drv" == "sfc" ]] ; then
-                ool_remove "netns_*" \
-                    "$info/SWNETLINUX-4809/Bug 11986: disable netns on SFC NICs with zc_af_xdp"
+                if ool_contains "netns_*" ; then
+                    ool_remove "netns_*" \
+                        "$info/SWNETLINUX-4809/Bug 11986: disable netns on SFC NICs with zc_af_xdp"
+                fi
             fi
         fi
 

--- a/sockapi-ts/ioctls/siocethtool_glink.c
+++ b/sockapi-ts/ioctls/siocethtool_glink.c
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
     }
 
     tapi_cfg_base_if_up(pco_iut->ta, iut_if->if_name);
-    CFG_WAIT_CHANGES;
+    CHECK_RC(sockts_wait_for_if_up(pco_iut, iut_if->if_name));
 
     rpc_ioctl(pco_iut, iut_s, RPC_SIOCETHTOOL, &ifreq_var);
 

--- a/sockapi-ts/performance/sfnt_pingpong.c
+++ b/sockapi-ts/performance/sfnt_pingpong.c
@@ -106,6 +106,11 @@ main(int argc, char *argv[])
     tapi_job_factory_rpc_create(pco_iut, &cl_factory);
     tapi_job_factory_rpc_create(pco_tst, &sv_factory);
 
+    /* Kill zombie stacks now to avoid killing them at stack creation moment.
+     * It takes time, and sfnt-pingpong is sensitive to execution time.
+     * See bug 12215.*/
+    sockts_kill_zombie_stacks(pco_iut);
+
     TEST_STEP("Create client and server of sfnt-pingpong");
     CHECK_RC(tapi_sfnt_pp_create(cl_factory, sv_factory,
                                  &opt,  &client, &server));


### PR DESCRIPTION
- get rid of the orphaned stacks at the end of the test basic/listen_shutdown_listen
- use the convenient function to wait for interface UP in the sockapi-ts/ioctls/siocethtool_glink
- make the ool_fix_consistency scripts more readable (and updatable)
- get rid of the orphaned stacks before sfnt-pingpong starts

-------------------
Tested by rebuilding the sapi-ts and running the tests manually - all OK.