### PR TITLE
sockopts/ipv6_only_bind: change according to new kernel version

### DIFF
--- a/sockapi-ts/sockopts/ipv6_only_bind.c
+++ b/sockapi-ts/sockopts/ipv6_only_bind.c
@@ -19,6 +19,7 @@
  *                      - @c any (@c IN6ADDR_ANY_INIT)
  *                      - @c ipv4
  *                      - @c ipv4_mapped (constructed from @p iut_addr)
+ *                      - @c ipv4_mapped_new (from @p env net)
  *                      - @c ipv4_mapped_any (IPv4-mapped IPv6 corresponding
  *                        to @c INADDR_ANY)
  *                      - @c ipv6
@@ -47,20 +48,22 @@
 
 /** Types of address to which a socket may be bound */
 typedef enum {
-    SOCKTS_ADDR_ANY,              /**< Wildcard address */
-    SOCKTS_ADDR_IPV4,             /**< IPv4 address */
-    SOCKTS_ADDR_IPV4_MAPPED,      /**< IPv4-mapped IPv6 */
-    SOCKTS_ADDR_IPV4_MAPPED_ANY,  /**< IPv4-mapped IPv6 corresponding to
-                                       INADDR_ANY */
-    SOCKTS_ADDR_IPV6,             /**< IPv6 address */
+    SOCKTS_ADDR_ANY,               /**< Wildcard address */
+    SOCKTS_ADDR_IPV4,              /**< IPv4 address */
+    SOCKTS_ADDR_IPV4_MAPPED,       /**< IPv4-mapped IPv6 */
+    SOCKTS_ADDR_IPV4_MAPPED_NEW,   /**< Another IPv4-mapped IPv6 */
+    SOCKTS_ADDR_IPV4_MAPPED_ANY,   /**< IPv4-mapped IPv6 corresponding to
+                                        INADDR_ANY */
+    SOCKTS_ADDR_IPV6,              /**< IPv6 address */
 } test_addr_type;
 
 /** List of address types to be used with TEST_GET_ENUM_PARAM() */
 #define TEST_ADDR_TYPES \
-    { "any", SOCKTS_ADDR_ANY },                         \
-    { "ipv4", SOCKTS_ADDR_IPV4 },                       \
-    { "ipv4_mapped", SOCKTS_ADDR_IPV4_MAPPED },         \
-    { "ipv4_mapped_any", SOCKTS_ADDR_IPV4_MAPPED_ANY }, \
+    { "any", SOCKTS_ADDR_ANY },                          \
+    { "ipv4", SOCKTS_ADDR_IPV4 },                        \
+    { "ipv4_mapped", SOCKTS_ADDR_IPV4_MAPPED },          \
+    { "ipv4_mapped_new", SOCKTS_ADDR_IPV4_MAPPED_NEW },  \
+    { "ipv4_mapped_any", SOCKTS_ADDR_IPV4_MAPPED_ANY },  \
     { "ipv6", SOCKTS_ADDR_IPV6 }
 
 int
@@ -70,6 +73,7 @@ main(int argc, char *argv[])
     rcf_rpc_server             *pco_tst = NULL;
     const struct sockaddr      *iut_addr6 = NULL;
     const struct sockaddr      *iut_addr = NULL;
+    struct sockaddr            *iut_addr_new = NULL;
     int                         iut_s6 = -1;
     int                         iut_s4 = -1;
     int                         iut_acc6 = -1;
@@ -83,6 +87,8 @@ main(int argc, char *argv[])
     const struct if_nameindex  *iut_if;
     sockts_if_monitor           iut_if_monitor4 = SOCKTS_IF_MONITOR_INIT;
     sockts_if_monitor           iut_if_monitor6 = SOCKTS_IF_MONITOR_INIT;
+    cfg_handle                  new_addr_handle = CFG_HANDLE_INVALID;
+    tapi_env_net               *net = NULL;
 
     test_addr_type    ipv6_bind;
     test_addr_type    ipv4_bind;
@@ -90,6 +96,8 @@ main(int argc, char *argv[])
     te_bool           v6only_after;
     rpc_socket_type   sock_type;
     te_bool           if_acc;
+    te_bool           should_bind_succeed;
+    te_bool           bind_condition;
 
     struct sockaddr_storage ipv6_bind_addr;
     struct sockaddr_storage ipv4_bind_addr;
@@ -107,6 +115,7 @@ main(int argc, char *argv[])
     TEST_GET_BOOL_PARAM(v6only_after);
     TEST_GET_SOCK_TYPE(sock_type);
     TEST_GET_IF(iut_if);
+    TEST_GET_NET(net);
 
     tapi_sockaddr_clone_exact(iut_addr6, &ipv6_bind_addr);
     tapi_sockaddr_clone_exact(iut_addr6, &ipv6_conn_addr);
@@ -122,10 +131,29 @@ main(int argc, char *argv[])
             tapi_sockaddr_clone_exact(SA(&ipv6_bind_addr), &ipv6_conn_addr);
             break;
 
+        case SOCKTS_ADDR_IPV4_MAPPED_NEW:
+            CHECK_RC(tapi_env_allocate_addr(net, AF_INET, &iut_addr_new, NULL));
+            CHECK_RC(tapi_allocate_set_port(pco_iut, iut_addr_new));
+            CHECK_RC(tapi_cfg_base_if_add_net_addr(pco_iut->ta, iut_if->if_name,
+                                                   iut_addr_new, net->ip4pfx,
+                                                   TRUE, &new_addr_handle));
+            CFG_WAIT_CHANGES;
+            /*@fallthrough@*/
+
         case SOCKTS_ADDR_IPV4_MAPPED:
             te_sockaddr_set_wildcard(SA(&ipv6_bind_addr));
-            SIN6(&ipv6_bind_addr)->sin6_addr.s6_addr32[3] =
-                SIN(iut_addr)->sin_addr.s_addr;
+
+            if (ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED)
+            {
+                SIN6(&ipv6_bind_addr)->sin6_addr.s6_addr32[3] =
+                    SIN(iut_addr)->sin_addr.s_addr;
+            }
+            else
+            {
+                SIN6(&ipv6_bind_addr)->sin6_addr.s6_addr32[3] =
+                    SIN(iut_addr_new)->sin_addr.s_addr;
+            }
+
             SIN6(&ipv6_bind_addr)->sin6_addr.s6_addr16[5] = htons(0xFFFF);
             tapi_sockaddr_clone_exact(SA(&ipv6_bind_addr), &ipv6_conn_addr);
             break;
@@ -225,7 +253,8 @@ main(int argc, char *argv[])
     }
     else if (opt_val == 1 &&
              (ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED ||
-              ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED_ANY))
+              ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED_ANY ||
+              ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED_NEW))
     {
         if (rc1 >= 0)
         {
@@ -288,23 +317,48 @@ main(int argc, char *argv[])
 
     TEST_STEP("Bind IPv4 IUT socket to an address chosen according to "
               "@p ipv4_bind and the same port that was used for IPv6 "
-              "socket. Check that @b bind() succeeds if binding failed "
-              "for IPv6 socket, or if @c IPV6_V6ONLY option was enabled "
-              "for it, or if it was bound to IPv6 address. Check that "
-              "@b bind() fails otherwise.");
+              "socket.");
 
     RPC_AWAIT_ERROR(pco_iut);
     rc2 = rpc_bind(pco_iut, iut_s4, SA(&ipv4_bind_addr));
-    if (rc1 < 0 || opt_val == 1 || ipv6_bind == SOCKTS_ADDR_IPV6)
+
+    should_bind_succeed = (rc1 < 0 || opt_val == 1
+                           || ipv6_bind == SOCKTS_ADDR_IPV6);
+    bind_condition = (ipv4_bind == SOCKTS_ADDR_IPV4 && (ipv6_bind
+                      == SOCKTS_ADDR_IPV4_MAPPED || ipv6_bind
+                      == SOCKTS_ADDR_IPV4_MAPPED_ANY));
+
+    if (should_bind_succeed)
     {
+        TEST_SUBSTEP("Check that @b bind() succeeds if binding failed "
+                     "for IPv6 socket, or if @c IPV6_V6ONLY option was "
+                     "enabled for it, or if it was bound to IPv6 address.");
         if (rc2 < 0)
         {
             TEST_VERDICT("Binding IPv4 socket failed unexpectedly with "
                          "errno %r", RPC_ERRNO(pco_iut));
         }
     }
+    else if ((bind_condition && sock_type == RPC_SOCK_STREAM)
+             || (ipv4_bind == SOCKTS_ADDR_IPV4 && ipv6_bind
+             == SOCKTS_ADDR_IPV4_MAPPED_NEW))
+    {
+        TEST_SUBSTEP("Check that @b bind() succeeds if either:\n"
+                     "1) IPv4 socket was bound to IPv4 address, IPv6 socket "
+                     "was bound to IPv4-mapped address (constructed from "
+                     "this address or INADDR_ANY) and socket type is TCP;\n"
+                     "2) or IPv4 socket was bound to IPv4 address and IPv6 "
+                     "socket was bound to another IPv4-mapped address.");
+        if (rc2 < 0)
+        {
+            RING_VERDICT("Binding IPv4 socket failed unexpectedly with "
+                         "errno %r", RPC_ERRNO(pco_iut));
+        }
+    }
     else
     {
+        TEST_SUBSTEP("Check that @b bind() fails otherwise.");
+
         if (rc2 >= 0)
         {
             TEST_VERDICT("Binding IPv4 socket unexpectedly succeeded");
@@ -342,25 +396,51 @@ main(int argc, char *argv[])
         sockts_if_monitor *monitor = &iut_if_monitor6;
 
         if (sock_type == RPC_SOCK_STREAM)
-            rpc_listen(pco_iut, iut_s6, SOCKTS_BACKLOG_DEF);
-
-        CHECK_RC(sockts_check_recv_accept(
-                                 pco_tst, tst_s6,
-                                 pco_iut, iut_s6,
-                                 NULL, SA(&ipv6_conn_addr), RPC_PF_UNSPEC,
-                                 sock_type, &iut_acc6, "IPv6 socket"));
-
-        TEST_SUBSTEP("Check acceleration for IPv6 socket.");
-        if (ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED ||
-            ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED_ANY)
         {
-            monitor = &iut_if_monitor4;
-        }
+            RPC_AWAIT_ERROR(pco_iut);
+            rc = rpc_listen(pco_iut, iut_s6, SOCKTS_BACKLOG_DEF);
+            if (rc2 >= 0 && bind_condition)
+            {
+                if (rc >= 0)
+                {
+                    TEST_VERDICT("listen() on IPv6 socket unexpectedly "
+                                 "succeeded");
+                }
+                else if (RPC_ERRNO(pco_iut) != RPC_EADDRINUSE)
+                {
+                    TEST_VERDICT("listen() on IPv6 socket failed with errno %r "
+                                 "instead of EADDRINUSE",
+                                 RPC_ERRNO(pco_iut));
+                }
+            }
+            else
+            {
+                if (rc < 0)
+                {
+                    TEST_VERDICT("listen() on IPv6 socket failed unexpectedly "
+                                 "with errno %r", RPC_ERRNO(pco_iut));
+                }
 
-        if (sockts_if_monitor_check_in(monitor) != !if_acc)
-        {
-            TEST_VERDICT("IPv6 socket: traffic over IUT interface is %s"
-                         "accelerated", (if_acc ? "not " : ""));
+                CHECK_RC(sockts_check_recv_accept(
+                                    pco_tst, tst_s6,
+                                    pco_iut, iut_s6,
+                                    NULL, SA(&ipv6_conn_addr), RPC_PF_UNSPEC,
+                                    sock_type, &iut_acc6, "IPv6 socket"));
+
+                TEST_SUBSTEP("Check acceleration for IPv6 socket.");
+                if (ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED ||
+                    ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED_ANY ||
+                    ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED_NEW)
+                {
+                    monitor = &iut_if_monitor4;
+                }
+
+                if (sockts_if_monitor_check_in(monitor) != !if_acc)
+                {
+                    TEST_VERDICT("IPv6 socket: traffic over IUT interface is %s"
+                                 "accelerated", (if_acc ? "not " : ""));
+                }
+            }
         }
     }
 
@@ -400,6 +480,11 @@ cleanup:
     CLEANUP_RPC_CLOSE(pco_iut, iut_acc6);
     CLEANUP_RPC_CLOSE(pco_tst, tst_s4);
     CLEANUP_RPC_CLOSE(pco_tst, tst_s6);
+
+    if (ipv6_bind == SOCKTS_ADDR_IPV4_MAPPED_NEW)
+    {
+        CLEANUP_CHECK_RC(cfg_del_instance(new_addr_handle, FALSE));
+    }
 
     TEST_END;
 }

--- a/sockapi-ts/sockopts/package.xml
+++ b/sockapi-ts/sockopts/package.xml
@@ -3279,6 +3279,7 @@
                 <value>any</value>
                 <value>ipv4</value>
                 <value>ipv4_mapped</value>
+                <value>ipv4_mapped_new</value>
                 <value>ipv4_mapped_any</value>
                 <value>ipv6</value>
             </arg>

--- a/trc/trc-sockapi-ts-sockopts.xml
+++ b/trc/trc-sockapi-ts-sockopts.xml
@@ -23089,11 +23089,157 @@
       <notes/>
       <iter result="PASSED">
         <arg name="env"/>
-        <arg name="ipv4_bind"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">TRUE</arg>
+        <arg name="v6only_after">TRUE</arg>
+        <notes/>
+        <results tags="linux&lt;6|linux-6&lt;1" notes="On earlier kernels behaviour may differ">
+          <result value="PASSED">
+            <verdict>Binding IPv4 socket failed unexpectedly with errno RPC-EADDRINUSE</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">FALSE</arg>
+        <arg name="v6only_after">FALSE</arg>
+        <notes/>
+        <results tags="linux&lt;6|linux-6&lt;1" notes="On earlier kernels behaviour may differ">
+          <result value="PASSED">
+            <verdict>Binding IPv4 socket failed unexpectedly with errno RPC-EADDRINUSE</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped_any</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">FALSE</arg>
+        <arg name="v6only_after">FALSE</arg>
+        <notes/>
+        <results tags="linux&lt;6|linux-6&lt;1" notes="On earlier kernels behaviour may differ">
+          <result value="PASSED">
+            <verdict>Binding IPv4 socket failed unexpectedly with errno RPC-EADDRINUSE</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped_any</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">TRUE</arg>
+        <arg name="v6only_after">TRUE</arg>
+        <notes/>
+        <results tags="linux&lt;6|linux-6&lt;1" notes="On earlier kernels behaviour may differ">
+          <result value="PASSED">
+            <verdict>Binding IPv4 socket failed unexpectedly with errno RPC-EADDRINUSE</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">any</arg>
         <arg name="ipv6_bind"/>
         <arg name="sock_type"/>
         <arg name="v6only"/>
         <arg name="v6only_after"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">any</arg>
+        <arg name="sock_type"/>
+        <arg name="v6only"/>
+        <arg name="v6only_after"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4</arg>
+        <arg name="sock_type"/>
+        <arg name="v6only"/>
+        <arg name="v6only_after"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv6</arg>
+        <arg name="sock_type"/>
+        <arg name="v6only"/>
+        <arg name="v6only_after"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped_new</arg>
+        <arg name="sock_type"/>
+        <arg name="v6only"/>
+        <arg name="v6only_after"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped</arg>
+        <arg name="sock_type">SOCK_DGRAM</arg>
+        <arg name="v6only"/>
+        <arg name="v6only_after"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped_any</arg>
+        <arg name="sock_type">SOCK_DGRAM</arg>
+        <arg name="v6only"/>
+        <arg name="v6only_after"/>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">TRUE</arg>
+        <arg name="v6only_after">FALSE</arg>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">FALSE</arg>
+        <arg name="v6only_after">TRUE</arg>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped_any</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">TRUE</arg>
+        <arg name="v6only_after">FALSE</arg>
+        <notes/>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="ipv4_bind">ipv4</arg>
+        <arg name="ipv6_bind">ipv4_mapped_any</arg>
+        <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="v6only">FALSE</arg>
+        <arg name="v6only_after">TRUE</arg>
         <notes/>
       </iter>
     </test>


### PR DESCRIPTION
Modify the test based on the change of behavior in Linux 6.1. Add new
iterations, with IPv6 socket bound to an IPv4-mapped address based on
a newly allocated address. Change TRC to account for test verdicts that
occur in previous Linux versions.

Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
