### PR TITLE
conf/scripts: use the additional library from TE

### DIFF
--- a/conf/scripts/sockapi-ts
+++ b/conf/scripts/sockapi-ts
@@ -7,6 +7,7 @@
 #
 . ${SF_TS_CONFDIR}/scripts/sfc_onload_gnu
 source "${TE_BASE}/scripts/lib"
+source "${TE_BASE}/engine/builder/te_ta_ssh_helper"
 
 # Include the file if it really exists - this allows sapi-ts not to break.
 # It seems that the following functions may become unavailable on some


### PR DESCRIPTION
The functions from the ts-conf/scripts/lib file now use the te_ta_ssh_helper library from TE.

OL-Redmine-Id: 13706

---------------
Checked by rebuilding sapi-ts:
```console
./run.sh -q --cfg=${CFG} --build-only
```