### PR TITLE
ioctls/fionbio_thread_unblock_send: remove whitespaces

### DIFF
--- a/sockapi-ts/ioctls/fionbio_thread_unblock_send.c
+++ b/sockapi-ts/ioctls/fionbio_thread_unblock_send.c
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* (c) Copyright 2004 - 2022 Xilinx, Inc. All rights reserved. */
-/* 
+/*
  * Socket API Test Suite
  * IOCTL Requests
- * 
+ *
  * $Id$
  */
 
@@ -15,7 +15,7 @@
  * @param pco_iut       PCO on IUT
  * @param pco_tst       PCO on TESTER
  * @param iut_addr      IUT IP address
- * @param tst_addr      TESTER IP address 
+ * @param tst_addr      TESTER IP address
  *
  * @par Test sequence:
  * -# Create stream socket @p iut_s on @p pco_iut.
@@ -29,11 +29,11 @@
  * -# Make socket @p iut_s non-blocking using @c FIONBIO IOCTL request
  *    from @p pco_iut_thread.
  * -# Check that @b send(@p iut_s, ...) on @p pco_iut is not done.
- * -# Check that @b send(@p iut_s, ...) on @p pco_iut_thread 
+ * -# Check that @b send(@p iut_s, ...) on @p pco_iut_thread
  *    fails with @b errno EAGAIN.
  * -# Call @b recv(@p acc_s, @p iut_addr) @p on pco_tst.
  * -# Check that @b send(@p iut_s, ...) on @p pco_iut is unblocked.
- * 
+ *
  * @author Konstantin Petrov <Konstantin.Petrov@oktetlabs.ru>
  */
 
@@ -63,17 +63,17 @@ main(int argc, char **argv)
     size_t                           tx_buf_len = SEND_BUF_LEN;
     size_t                           rx_buf_len = RECV_BUF_LEN;
     uint64_t                         sent;
-    
+
     TEST_START;
     TEST_GET_PCO(pco_iut);
     TEST_GET_PCO(pco_tst);
     TEST_GET_ADDR(pco_iut, iut_addr);
     TEST_GET_ADDR(pco_tst, tst_addr);
-    
+
     CHECK_RC(rcf_rpc_server_thread_create(pco_iut,
                                           "IUT_thread",
                                           &pco_iut_thread));
-    
+
     iut_s = rpc_socket(pco_iut,
                        rpc_socket_domain_by_addr(iut_addr),
                        RPC_SOCK_STREAM,
@@ -82,7 +82,7 @@ main(int argc, char **argv)
                        rpc_socket_domain_by_addr(tst_addr),
                        RPC_SOCK_STREAM,
                        RPC_IPPROTO_TCP);
-    
+
     rpc_bind(pco_iut, iut_s, iut_addr);
     rpc_bind(pco_tst, tst_s, tst_addr);
 
@@ -92,33 +92,33 @@ main(int argc, char **argv)
         TEST_FAIL("Unable to accept connection on pco_tst side");
 
     rpc_overfill_buffers(pco_iut, iut_s, &sent);
-            
+
     pco_iut->op = RCF_RPC_CALL;
     rpc_send(pco_iut, iut_s, tx_buf, tx_buf_len, 0);
-    
+
     req_val = TRUE;
     rpc_ioctl(pco_iut_thread, iut_s, RPC_FIONBIO, &req_val);
     TAPI_WAIT_NETWORK;
-    
+
     CHECK_RC(rcf_rpc_server_is_op_done(pco_iut, &is_done));
     if (!is_done)
     {
         RPC_AWAIT_IUT_ERROR(pco_iut_thread);
         if (rpc_send(pco_iut_thread, iut_s, tx_buf, tx_buf_len, 0) != -1)
             TEST_VERDICT("send() on non-blocking socket succeed");
-        
+
         CHECK_RPC_ERRNO(pco_iut_thread, RPC_EAGAIN,
                         "send() on non-blocking socket failed");
-        
+
         rpc_drain_fd_simple(pco_tst, acc_s, NULL);
-        
+
         TAPI_WAIT_NETWORK;
 
         CHECK_RC(rcf_rpc_server_is_op_done(pco_iut, &is_done));
         if (is_done)
         {
             pco_iut->op = RCF_RPC_WAIT;
-            
+
             if (rpc_send(pco_iut, iut_s, tx_buf, tx_buf_len, 0) == -1)
                 TEST_VERDICT("Blocked send() failed unexpectedly");
         }
@@ -132,7 +132,7 @@ main(int argc, char **argv)
     {
         RPC_AWAIT_IUT_ERROR(pco_iut);
         pco_iut->op = RCF_RPC_WAIT;
-        
+
         if (rpc_send(pco_iut, iut_s, tx_buf, tx_buf_len, 0) == -1)
         {
             CHECK_RPC_ERRNO(pco_iut, RPC_EAGAIN,
@@ -146,7 +146,7 @@ main(int argc, char **argv)
     TEST_SUCCESS;
 
 cleanup:
-    
+
     CLEANUP_RPC_CLOSE(pco_iut, iut_s);
     CLEANUP_RPC_CLOSE(pco_tst, tst_s);
     CLEANUP_RPC_CLOSE(pco_tst, acc_s);
@@ -156,4 +156,3 @@ cleanup:
 
     TEST_END;
 }
-


### PR DESCRIPTION
Remove whitespaces from empty lines.

Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>
