### PR TITLE
sockopts/tcp_quickack: enable TCP_NODELAY

### DIFF
--- a/sockapi-ts/sockopts/tcp_quickack.c
+++ b/sockapi-ts/sockopts/tcp_quickack.c
@@ -59,6 +59,7 @@ main(int argc, char *argv[])
     const struct sockaddr *tst_addr = NULL;
     int                    sent;
     int                    opt_val;
+    int                    opt_val_nodelay = 1;
     int                    opt_get;
     unsigned char          tx_buf[1] = { 234 };
     unsigned char          rx_buf[100];
@@ -86,6 +87,8 @@ main(int argc, char *argv[])
 
     GEN_CONNECTION(pco_iut, pco_tst, RPC_SOCK_STREAM, RPC_PROTO_DEF,
                    iut_addr, tst_addr, &iut_s, &tst_s);
+
+    rpc_setsockopt(pco_tst, tst_s, RPC_TCP_NODELAY, &opt_val_nodelay);
 
     /* Open congestion window, drop linux neighbour cached values. */
     {


### PR DESCRIPTION
Enable the option TCP_NODELAY to increase stability of the test.
This resolves unlikely but possible situations when packets are getting
merged, resulting in fewer ACKs.

Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>
