### PR TITLE
talib/rpc: build fix for te_bool deprecation

### DIFF
--- a/talib_sockapi_ts/rpc.c
+++ b/talib_sockapi_ts/rpc.c
@@ -6763,7 +6763,7 @@ TARPC_FUNC(send_traffic, {},
     out->common._errno = 0;
     for (i = 0; i < in->num; i++)
     {
-        PREPARE_ADDR_GEN(to, in->to.to_val[i], 0, FALSE, TRUE);
+        PREPARE_ADDR_GEN(to, in->to.to_val[i], 0, false, true);
         addr_arr[i] = to_dup;
         addr_len[i] = tolen;
     }


### PR DESCRIPTION
This is necessary in order for the sapi-ts to be built after changes in the test-environment repository.

Checked with the following command line `$ ./run.sh -q --cfg=${MYCFG} --build-only` on:
- ts-conf: https://github.com/Xilinx-CNS/cns-ts-conf/commit/a5944c05ccd9e77a1487cb19334df973ff4cd43d
- te: https://github.com/oktetlabs/test-environment/commit/f5a037581a21fc0a44adc2108d7e79604f5d4d93

