### PR TITLE
iomux/timeout_update: fix TRC for ppoll

### DIFF
--- a/trc/trc-sockapi-ts-iomux.xml
+++ b/trc/trc-sockapi-ts-iomux.xml
@@ -18,6 +18,11 @@
         <arg name="env"/>
         <arg name="iomux">ppoll</arg>
         <notes/>
+        <results tags="linux&amp;syscall">
+          <result value="FAILED">
+            <verdict>Timeout parameter was modified by ppoll() function</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>


### PR DESCRIPTION
Fix TRC for linux syscall run