### PR TITLE
sockopts/max_bufs: check TCP dyn buf limits don't limit buf

### DIFF
--- a/sockapi-ts/sockopts/max_bufs.c
+++ b/sockapi-ts/sockopts/max_bufs.c
@@ -25,6 +25,8 @@
  *                            - @c none (do not change)
  *                            - @c increase
  *                            - @c decrease
+ * @param small_tcp_bufs      If @c TRUE, decrease @c tcp_rmem[2] /
+ *                            @c tcp_wmem[2] to be less than buffer size
  *
  * @par Test sequence:
  *
@@ -183,6 +185,7 @@ main(int argc, char *argv[])
 
     rpc_socket_type sock_type;
     te_bool check_sndbuf;
+    te_bool small_tcp_bufs;
     max_change_type max_value_change;
 
     const char *max_conf_path;
@@ -191,6 +194,10 @@ main(int argc, char *argv[])
     int new_buf_max;
     rpc_sockopt opt;
     int val;
+    char *dyn_tcp_buf_max_conf_path;
+    int dyn_tcp_buf_max;
+    int orig_dyn_tcp_buf_max;
+    int new_dyn_tcp_buf_max;
 
     te_bool test_failed = FALSE;
 
@@ -199,23 +206,23 @@ main(int argc, char *argv[])
     TEST_GET_ADDR(pco_iut, iut_addr);
     TEST_GET_SOCK_TYPE(sock_type);
     TEST_GET_BOOL_PARAM(check_sndbuf);
+    TEST_GET_BOOL_PARAM(small_tcp_bufs);
     TEST_GET_ENUM_PARAM(max_value_change, MAX_CHANGE_TYPES);
 
-    /*
-     * Note: for TCP tcp_wmem and tcp_rmem should not be taken into
-     * account here; they are used for dymanic TCP buffers adjustment
-     * and do not limit SO_SNDBUF/SO_RCVBUF according to Linux manual.
-     */
+    if (sock_type != RPC_SOCK_STREAM && small_tcp_bufs)
+        TEST_SKIP("Small TCP buffers can be tested only for SOCK_STREAM");
 
     if (check_sndbuf)
     {
         max_conf_path = "net/core/wmem_max";
         opt = RPC_SO_SNDBUF;
+        dyn_tcp_buf_max_conf_path = "net/ipv4/tcp_wmem:2";
     }
     else
     {
         max_conf_path = "net/core/rmem_max";
         opt = RPC_SO_RCVBUF;
+        dyn_tcp_buf_max_conf_path = "net/ipv4/tcp_rmem:2";
     }
 
     TEST_STEP("Obtain the current value of system-wide maximum "
@@ -240,6 +247,33 @@ main(int argc, char *argv[])
         CHECK_RC(rcf_rpc_server_restart(pco_iut));
         orig_buf_max = buf_max;
         buf_max = new_buf_max;
+    }
+
+    if (small_tcp_bufs)
+    {
+        /*
+         * TCP tcp_wmem and tcp_rmem are used for dymanic TCP buffers
+         * adjustment and do not limit SO_SNDBUF/SO_RCVBUF according to
+         * Linux manual. Therefore we reduce these values to be less
+         * than buf_max.
+         */
+        TEST_STEP("Obtain @p tcp_wmem[2] / @p tcp_rmem[2] to see if we need "
+                  "to reduce it if it is greater than buffer max.");
+        CHECK_RC(tapi_cfg_sys_ns_get_int(pco_iut->ta, &dyn_tcp_buf_max,
+                                         dyn_tcp_buf_max_conf_path));
+        orig_dyn_tcp_buf_max = dyn_tcp_buf_max;
+        if (buf_max <= dyn_tcp_buf_max)
+        {
+            new_dyn_tcp_buf_max = buf_max / 2;
+
+            RING("Changing %s from %d to %d", dyn_tcp_buf_max_conf_path,
+                 dyn_tcp_buf_max, new_dyn_tcp_buf_max);
+            CHECK_RC(tapi_cfg_sys_ns_set_int(pco_iut->ta, new_dyn_tcp_buf_max,
+                                             NULL,
+                                             dyn_tcp_buf_max_conf_path));
+            CHECK_RC(rcf_rpc_server_restart(pco_iut));
+            dyn_tcp_buf_max = new_dyn_tcp_buf_max;
+        }
     }
 
     RING("System-wide maximum is %d (if doubled: %d)", buf_max,
@@ -284,6 +318,13 @@ cleanup:
     {
         CLEANUP_CHECK_RC(tapi_cfg_sys_ns_set_int(pco_iut->ta, orig_buf_max,
                                                  NULL, max_conf_path));
+        CLEANUP_CHECK_RC(rcf_rpc_server_restart(pco_iut));
+    }
+    if (small_tcp_bufs && dyn_tcp_buf_max != orig_dyn_tcp_buf_max)
+    {
+        CLEANUP_CHECK_RC(tapi_cfg_sys_ns_set_int(pco_iut->ta,
+                                                 orig_dyn_tcp_buf_max, NULL,
+                                                 dyn_tcp_buf_max_conf_path));
         CLEANUP_CHECK_RC(rcf_rpc_server_restart(pco_iut));
     }
 

--- a/sockapi-ts/sockopts/package.xml
+++ b/sockapi-ts/sockopts/package.xml
@@ -543,7 +543,16 @@
             <script name="max_bufs" track_conf="silent">
                 <req id="PROC_SYS_NET"/>
             </script>
-            <arg name="sock_type" type="sock_stream_dgram"/>
+            <arg name="sock_type" type="sock_stream_dgram" list="">
+                <value>SOCK_STREAM</value>
+                <value>SOCK_STREAM</value>
+                <value>SOCK_DGRAM</value>
+            </arg>
+            <arg name="small_tcp_bufs" list="">
+                <value>TRUE</value>
+                <value>FALSE</value>
+                <value>FALSE</value>
+            </arg>
             <arg name="env">
                 <value ref="env.iut_ucast"/>
                 <value ref="env.iut_ucast_ipv6"/>

--- a/trc/trc-sockapi-ts-sockopts.xml
+++ b/trc/trc-sockapi-ts-sockopts.xml
@@ -20113,6 +20113,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <arg name="sock_type">SOCK_DGRAM</arg>
+        <arg name="small_tcp_bufs">FALSE</arg>
         <arg name="check_sndbuf"/>
         <arg name="max_value_change"/>
         <notes/>
@@ -20120,6 +20121,7 @@
       <iter result="PASSED">
         <arg name="env"/>
         <arg name="sock_type">SOCK_STREAM</arg>
+        <arg name="small_tcp_bufs"/>
         <arg name="check_sndbuf"/>
         <arg name="max_value_change"/>
         <notes/>


### PR DESCRIPTION
TCP iterations of the test are extended to check that tcp_wmem[2] and tcp_rmem[2] do not limit SO_SNDBUF/SO_RCVBUF socket options.

Link: https://github.com/Xilinx-CNS/cns-sapi-ts/issues/102
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>