### PR TITLE
conf: fix build because of PCRE version change

### DIFF
--- a/conf/builder.conf
+++ b/conf/builder.conf
@@ -107,7 +107,7 @@ define([TE_AGENT_BUILD], [
             TE_TA_APP([ta_rpcprovider], [${$1_TA_TYPE}], [${$1_TA_TYPE}], [ta_rpcprovider], [], [],
                       [talib_sockapi_ts rpcs_serial ta_job rpcs_job rpcserver agentlib rpcxdrta \
                        rpc_types rpctransport loggerta tools logger_core],
-                      [\${EXT_SOURCES}/build.sh --extra-deps='libpcre'],
+                      [\${EXT_SOURCES}/build.sh --extra-deps='libpcre2-8'],
                       [ta_rpcs], [])
 
             if test -n "$BPF_CFG" ; then


### PR DESCRIPTION
TE now uses PCRE 2 instead of old PCRE.

---------------------

Checked with TE v1.47.3