### PR TITLE
User/okt kosovnn/nonblock addition

### DIFF
--- a/sockapi-ts/level5/interop/meson.build
+++ b/sockapi-ts/level5/interop/meson.build
@@ -13,7 +13,7 @@ tests = [
     'close_read',
     'close_shutdown_socket',
     'close_udp_readable_socket',
-    'fcntl_nonblock',
+    'derived_nonblock',
     'nonblock',
     'nonblock_handover',
     'onload_msg_recv_os_inline',

--- a/sockapi-ts/level5/interop/package.xml
+++ b/sockapi-ts/level5/interop/package.xml
@@ -439,6 +439,7 @@
                     <arg name="nonblock_func">
                         <value>fcntl</value>
                         <value reqs="SOCK_NONBLOCK">socket</value>
+                        <value>ioctl</value>
                     </arg>
                 </run>
             </session>

--- a/sockapi-ts/level5/interop/package.xml
+++ b/sockapi-ts/level5/interop/package.xml
@@ -248,7 +248,7 @@
                 </arg>
 
                 <run>
-                    <script name="fcntl_nonblock"/>
+                    <script name="derived_nonblock"/>
                     <arg name="is_pipe">
                         <value>FALSE</value>
                     </arg>
@@ -258,7 +258,7 @@
                         <value>TRUE</value>
                         <value>FALSE</value>
                     </arg>
-                    <arg name="fcntl_sys_call" list="iut_sys">
+                    <arg name="nonblock_sys_call" list="iut_sys">
                         <value>TRUE</value>
                         <value>FALSE</value>
                         <value>FALSE</value>
@@ -278,11 +278,12 @@
                     </arg>
                     <arg name="nonblock_func">
                         <value>fcntl</value>
+                        <value>ioctl</value>
                     </arg>
                 </run>
 
                 <run>
-                    <script name="fcntl_nonblock"/>
+                    <script name="derived_nonblock"/>
                     <arg name="is_pipe">
                         <value>FALSE</value>
                     </arg>
@@ -294,7 +295,7 @@
                         <value>FALSE</value>
                         <value>TRUE</value>
                     </arg>
-                    <arg name="fcntl_sys_call" list="iut_sys">
+                    <arg name="nonblock_sys_call" list="iut_sys">
                         <value>TRUE</value>
                         <value>TRUE</value>
                         <value>TRUE</value>
@@ -320,18 +321,19 @@
                     </arg>
                     <arg name="nonblock_func">
                         <value>fcntl</value>
+                        <value>ioctl</value>
                     </arg>
                 </run>
 
                 <run>
-                    <script name="fcntl_nonblock">
+                    <script name="derived_nonblock">
                       <req id="SOCK_NONBLOCK"/>
                     </script>
                     <arg name="is_pipe">
                         <value>FALSE</value>
                     </arg>
                     <arg name="change_iut" type="boolean"/>
-                    <arg name="fcntl_sys_call" type="syscall_bool"/>
+                    <arg name="nonblock_sys_call" type="syscall_bool"/>
                     <arg name="iut_sys_call" type="syscall_bool"/>
                     <arg name="start_blocking" type="boolean">
                         <value>FALSE</value>
@@ -352,7 +354,7 @@
                 </run>
 
                 <run>
-                    <script name="fcntl_nonblock">
+                    <script name="derived_nonblock">
                       <req id="ACCEPT4"/>
                       <req id="SOCK_NONBLOCK"/>
                     </script>
@@ -360,7 +362,7 @@
                         <value>FALSE</value>
                     </arg>
                     <arg name="change_iut" type="boolean"/>
-                    <arg name="fcntl_sys_call" type="syscall_bool"/>
+                    <arg name="nonblock_sys_call" type="syscall_bool"/>
                     <arg name="iut_sys_call" type="syscall_bool"/>
                     <arg name="start_blocking" type="boolean">
                         <value>FALSE</value>
@@ -379,7 +381,7 @@
             </session>
         </run>
         <run>
-            <script name="fcntl_nonblock">
+            <script name="derived_nonblock">
             </script>
             <arg name="env" ref="env.iut_only"/>
             <arg name="is_pipe">
@@ -392,7 +394,7 @@
             </arg>
             <arg name="start_blocking" type="boolean"/>
             <arg name="change_iut" type="boolean"/>
-            <arg name="fcntl_sys_call" type="boolean"/>
+            <arg name="nonblock_sys_call" type="boolean"/>
             <arg name="iut_sys_call" type="boolean"/>
             <arg name="func">
                 <value>read</value>
@@ -400,6 +402,7 @@
             </arg>
             <arg name="nonblock_func">
                 <value>fcntl</value>
+                <value>ioctl</value>
                 <value reqs="PIPE2">pipe2</value>
             </arg>
         </run>

--- a/sockapi-ts/nonblock/package.xml
+++ b/sockapi-ts/nonblock/package.xml
@@ -52,9 +52,9 @@
             <arg name="nonblock_func" type="fd_ctl_type"/>
             <arg name="libc_switch_mode">
               <value>none</value>
-              <value>before_nb</value>
-              <value>after_nb</value>
-              <value>after_func</value>
+              <value reqs="ONLOAD_ONLY,OOL_INTEROP">before_nb</value>
+              <value reqs="ONLOAD_ONLY,OOL_INTEROP">after_nb</value>
+              <value reqs="ONLOAD_ONLY,OOL_INTEROP">after_func</value>
             </arg>
         </run>
 

--- a/sockapi-ts/package.xml
+++ b/sockapi-ts/package.xml
@@ -1032,7 +1032,7 @@ Sending and receiving functions
         </enum>
 
         <enum name="fd_ctl_type">
-            <value reqs="FIONBIO">fcntl</value>
+            <value reqs="FCNTL">fcntl</value>
             <value reqs="IOCTLS">ioctl</value>
         </enum>
 

--- a/trc/trc-sockapi-ts-level5.xml
+++ b/trc/trc-sockapi-ts-level5.xml
@@ -964,14 +964,14 @@
             </results>
           </iter>
         </test>
-        <test name="fcntl_nonblock" type="script">
+        <test name="derived_nonblock" type="script">
           <objective>Check that O_NONBLOCK flag can be changed from different processes by L5 and libc implementations of fcntl().</objective>
           <notes/>
           <iter result="PASSED">
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -993,7 +993,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -1010,7 +1010,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">FALSE</arg>
+            <arg name="nonblock_sys_call">FALSE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -1027,7 +1027,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call">FALSE</arg>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">FALSE</arg>
@@ -1050,7 +1050,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call">TRUE</arg>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">FALSE</arg>
@@ -1073,7 +1073,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">TRUE</arg>
@@ -1091,7 +1091,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">FALSE</arg>
+            <arg name="nonblock_sys_call">FALSE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -1109,7 +1109,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">FALSE</arg>
@@ -1132,7 +1132,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">TRUE</arg>
@@ -1150,7 +1150,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">FALSE</arg>
+            <arg name="nonblock_sys_call">FALSE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -1168,7 +1168,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">FALSE</arg>
@@ -1186,7 +1186,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -1203,7 +1203,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">TRUE</arg>
@@ -1216,7 +1216,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">FALSE</arg>
+            <arg name="nonblock_sys_call">FALSE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -1229,7 +1229,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">FALSE</arg>
+            <arg name="nonblock_sys_call">FALSE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
@@ -1241,7 +1241,7 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call">FALSE</arg>
@@ -1259,11 +1259,101 @@
             <arg name="change_iut"/>
             <arg name="child_sys_call"/>
             <arg name="env"/>
-            <arg name="fcntl_sys_call">TRUE</arg>
+            <arg name="nonblock_sys_call">TRUE</arg>
             <arg name="func"/>
             <arg name="is_pipe"/>
             <arg name="iut_sys_call"/>
             <arg name="nonblock_func">fcntl</arg>
+            <arg name="start_blocking">FALSE</arg>
+            <notes/>
+            <results tags="v5" key="ON-751">
+              <result value="FAILED">
+                <verdict>Check blocking state on pco_iut: Failed unexpectedly with errno RPC-EAGAIN</verdict>
+              </result>
+            </results>
+          </iter>
+          <iter result="PASSED">
+            <arg name="change_iut"/>
+            <arg name="child_sys_call"/>
+            <arg name="env"/>
+            <arg name="nonblock_sys_call">TRUE</arg>
+            <arg name="func"/>
+            <arg name="is_pipe"/>
+            <arg name="iut_sys_call"/>
+            <arg name="nonblock_func">ioctl</arg>
+            <arg name="start_blocking">TRUE</arg>
+            <notes/>
+            <results tags="v5" key="ON-751">
+              <result value="FAILED">
+                <verdict>Check blocking state on pco_iut: Failed with RCF_PCH-ERPCTIMEOUT errno instead of EAGAIN</verdict>
+              </result>
+            </results>
+          </iter>
+          <iter result="PASSED">
+            <arg name="change_iut"/>
+            <arg name="child_sys_call"/>
+            <arg name="env"/>
+            <arg name="nonblock_sys_call">TRUE</arg>
+            <arg name="func"/>
+            <arg name="is_pipe"/>
+            <arg name="iut_sys_call">TRUE</arg>
+            <arg name="nonblock_func">ioctl</arg>
+            <arg name="sock_type"/>
+            <arg name="start_blocking"/>
+            <notes/>
+          </iter>
+          <iter result="PASSED">
+            <arg name="change_iut"/>
+            <arg name="child_sys_call"/>
+            <arg name="env"/>
+            <arg name="nonblock_sys_call">FALSE</arg>
+            <arg name="func"/>
+            <arg name="is_pipe"/>
+            <arg name="iut_sys_call"/>
+            <arg name="nonblock_func">ioctl</arg>
+            <arg name="sock_type"/>
+            <arg name="start_blocking"/>
+            <notes/>
+          </iter>
+          <iter result="PASSED">
+            <arg name="change_iut"/>
+            <arg name="child_sys_call"/>
+            <arg name="env"/>
+            <arg name="nonblock_sys_call">FALSE</arg>
+            <arg name="func"/>
+            <arg name="is_pipe"/>
+            <arg name="iut_sys_call"/>
+            <arg name="nonblock_func">ioctl</arg>
+            <arg name="start_blocking"/>
+            <notes/>
+          </iter>
+          <iter result="PASSED">
+            <arg name="change_iut"/>
+            <arg name="child_sys_call"/>
+            <arg name="env"/>
+            <arg name="nonblock_sys_call">TRUE</arg>
+            <arg name="func"/>
+            <arg name="is_pipe"/>
+            <arg name="iut_sys_call">FALSE</arg>
+            <arg name="nonblock_func">ioctl</arg>
+            <arg name="sock_type"/>
+            <arg name="start_blocking">FALSE</arg>
+            <notes/>
+            <results tags="v5" key="ON-751">
+              <result value="FAILED">
+                <verdict>Check blocking state on pco_iut: Failed unexpectedly with errno RPC-EAGAIN</verdict>
+              </result>
+            </results>
+          </iter>
+          <iter result="PASSED">
+            <arg name="change_iut"/>
+            <arg name="child_sys_call"/>
+            <arg name="env"/>
+            <arg name="nonblock_sys_call">TRUE</arg>
+            <arg name="func"/>
+            <arg name="is_pipe"/>
+            <arg name="iut_sys_call"/>
+            <arg name="nonblock_func">ioctl</arg>
             <arg name="start_blocking">FALSE</arg>
             <notes/>
             <results tags="v5" key="ON-751">


### PR DESCRIPTION
Some addition to nonblock series.
level5/interop/nonblock: add ioctl to DGRAM case
```
../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=af_xdp  --ool=no_reuse_pco --tester-run=sockapi-ts/level5/interop/nonblock
```
Some failures.
nonblock/nonblock: add reqs when libc variant of func is used
sockapi-ts: correct reqs for fd control type
level5/interop/fcntl_nonblock: add nonblocking via ioctl
```
../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=af_xdp  --ool=no_reuse_pco --tester-run=sockapi-ts/level5/interop/derived_nonblock
```
Not green rans are ioctl runs.