### PR TITLE
bnbvalue/func_splice_nonconn_dgram: fix TRC

### DIFF
--- a/trc/trc-sockapi-ts-bnbvalue.xml
+++ b/trc/trc-sockapi-ts-bnbvalue.xml
@@ -4204,7 +4204,7 @@
         <arg name="bound_socket"/>
         <arg name="set_move"/>
         <arg name="unblock_same_sock">TRUE</arg>
-        <results tags="v5" key="ON-16792">
+        <results tags="v5&amp;!udp_connect_no_handover" key="ON-16792">
           <result value="FAILED">
             <verdict>write() is unexpectedly not completed when UDP socket connected to itself</verdict>
           </result>


### PR DESCRIPTION
```
 ../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=af_xdp  --ool=no_reuse_pco --ool=udp_connect_no_handover  --tester-run=sockapi-ts/bnbvalue/func_splice_nonconn_dgram
```
and
```
 ../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=af_xdp  --ool=no_reuse_pco --tester-run=sockapi-ts/bnbvalue/func_splice_nonconn_dgram
```
Unexpected test results look like
```
ERROR: Unexpected test result

Obtained result:
Status: FAILED
Verdicts:
 *  Test caught the SIGUSR2 signal

Expected results:

Status: PASSED
```