### PR TITLE
ts: remove unnecessary return value checks

### DIFF
--- a/sockapi-ts/basic/diff_ipvlan_macvlan_check.c
+++ b/sockapi-ts/basic/diff_ipvlan_macvlan_check.c
@@ -135,8 +135,7 @@ create_configure_macvlan_or_ipvlan(rcf_rpc_server *pco_iut,
     te_string if_name = TE_STRING_INIT;
     *vlan_if_configured = FALSE;
 
-    CHECK_RC(te_string_append(&if_name, "%svlan_%d",
-                              (macvlan ? "mac" : "ip"), if_id));
+    te_string_append(&if_name, "%svlan_%d", (macvlan ? "mac" : "ip"), if_id);
     *vlan_if_name = if_name.ptr;
     if (macvlan)
     {

--- a/sockapi-ts/bnbvalue/ipv4_mapped_in_ipv6.c
+++ b/sockapi-ts/bnbvalue/ipv4_mapped_in_ipv6.c
@@ -102,12 +102,7 @@ ipv4_callback(const tapi_ip4_packet_t *pkt, void *userdata)
 static void
 te_string_append_flag(te_string *str, const char *flag)
 {
-    te_errno rc;
-
-    rc = te_string_append(str, "%s%s", (str->len > 0 ? "|" : ""),
-                          flag);
-    if (rc != 0)
-        ERROR("te_string_append() returned %r", rc);
+    te_string_append(str, "%s%s", (str->len > 0 ? "|" : ""), flag);
 }
 
 /**

--- a/sockapi-ts/bpf/xdp_bpf_helpers.c
+++ b/sockapi-ts/bpf/xdp_bpf_helpers.c
@@ -135,7 +135,7 @@ main(int argc, char *argv[])
     tapi_sniffer_add(pco_tst->ta, tst_if->if_name, NULL, NULL, TRUE);
 
     TEST_STEP("Add and load into the kernel @p prog_name on IUT.");
-    CHECK_RC(te_string_append(&obj_name, "%s%s", prog_name, BPF_OBJ_NAME_SFX));
+    te_string_append(&obj_name, "%s%s", prog_name, BPF_OBJ_NAME_SFX);
     bpf_path = sockts_bpf_get_path(pco_iut, iut_if->if_name, obj_name.ptr);
     rc = sockts_bpf_obj_init(pco_iut, iut_if->if_name, bpf_path,
                              TAPI_BPF_PROG_TYPE_XDP, &bpf_id);

--- a/sockapi-ts/bpf/xdp_prog_load.c
+++ b/sockapi-ts/bpf/xdp_prog_load.c
@@ -117,7 +117,7 @@ main(int argc, char *argv[])
     TEST_GET_ENUM_PARAM(check_type, CHECK_TYPE_VALUES);
 
     TEST_STEP("Add and load into the kernel @p prog_name on IUT.");
-    CHECK_RC(te_string_append(&obj_name, "%s%s", prog_name, BPF_OBJ_NAME_SFX));
+    te_string_append(&obj_name, "%s%s", prog_name, BPF_OBJ_NAME_SFX);
     bpf_path = sockts_bpf_get_path(pco_iut, iut_if->if_name, obj_name.ptr);
     rc = sockts_bpf_obj_init(pco_iut, iut_if->if_name, bpf_path,
                              TAPI_BPF_PROG_TYPE_XDP, &bpf_id);

--- a/sockapi-ts/checksum/bad_udp_csum.c
+++ b/sockapi-ts/checksum/bad_udp_csum.c
@@ -265,7 +265,7 @@ main(int argc, char *argv[])
                                       SIN(iut_addr)->sin_port,
                                       &csap));
 
-        CHECK_RC(te_string_append(&str, "{ pdus { udp:{}, ip4:{}, eth:{} } }"));
+        te_string_append(&str, "{ pdus { udp:{}, ip4:{}, eth:{} } }");
     }
     else
     {
@@ -283,7 +283,7 @@ main(int argc, char *argv[])
                                       SIN6(iut_addr)->sin6_port,
                                       &csap));
 
-        CHECK_RC(te_string_append(&str, "{ pdus { udp:{}, ip6:{}, eth:{} } }"));
+        te_string_append(&str, "{ pdus { udp:{}, ip6:{}, eth:{} } }");
     }
 
     CHECK_RC(asn_parse_value_text(str.ptr, ndn_traffic_template,

--- a/sockapi-ts/epoll/small_maxevents.c
+++ b/sockapi-ts/epoll/small_maxevents.c
@@ -312,8 +312,9 @@ main(int argc, char *argv[])
             }
 
             if (conn->use_libc)
-                CHECK_RC(te_string_append(&fds_str, "%s", "libc."));
-            CHECK_RC(te_string_append(&fds_str, "%d, ", fd));
+                te_string_append(&fds_str, "%s", "libc.");
+
+            te_string_append(&fds_str, "%d, ", fd);
 
             memcpy(&conn->last_reported, &cur_ts, sizeof(cur_ts));
 
@@ -332,22 +333,21 @@ main(int argc, char *argv[])
                          conn->sent_len, 0);
 
                 if (conn->use_libc)
-                    CHECK_RC(te_string_append(&proc_str, "%s", "libc."));
-                CHECK_RC(te_string_append(&proc_str, "%d, ", fd));
+                    te_string_append(&proc_str, "%s", "libc.");
+
+                te_string_append(&proc_str, "%d, ", fd);
             }
         }
 
         te_string_cut(&fds_str, 2);
         te_string_cut(&proc_str, 2);
         te_string_reset(&str_log);
-        CHECK_RC(te_string_append(&str_log,
-                                  "Events were reported for FDs %s",
-                                  fds_str.ptr));
+        te_string_append(&str_log, "Events were reported for FDs %s",
+                         fds_str.ptr);
         if (proc_str.len > 0)
         {
-            CHECK_RC(te_string_append(&str_log,
-                                      "; events were processed for FDs %s",
-                                      proc_str.ptr));
+            te_string_append(&str_log, "; events were processed for FDs %s",
+                             proc_str.ptr);
         }
 
         RING("%s", str_log.ptr);

--- a/sockapi-ts/level5/extension/oo_epoll.c
+++ b/sockapi-ts/level5/extension/oo_epoll.c
@@ -514,10 +514,8 @@ data_transmission_loop(rcf_rpc_server *pco_iut, rcf_rpc_server *pco_tst,
         {
             if (rand_range(1, MAX(pkts_per_stream / 2, 1)) == 1)
             {
-                CHECK_RC(
-                    te_string_append(&log_buf,
-                                     "Make IUT socket %d writable\n",
-                                     conns[j].iut_s));
+                te_string_append(&log_buf, "Make IUT socket %d writable\n",
+                                 conns[j].iut_s);
                 RPC_AWAIT_ERROR(pco_tst);
                 pco_tst->silent_pass = TRUE;
                 rc = rpc_drain_fd(pco_tst, conns[j].tst_s, max_size,
@@ -569,12 +567,11 @@ data_transmission_loop(rcf_rpc_server *pco_iut, rcf_rpc_server *pco_tst,
             exp_bytes = 0;
         }
 
-        CHECK_RC(
-          te_string_append(
+        te_string_append(
               &log_buf,
               "%d bytes were sent to IUT socket %d, %d bytes should "
               "be reported in the related event now\n",
-              pkt_size, conns[j].iut_s, exp_bytes));
+              pkt_size, conns[j].iut_s, exp_bytes);
 
         if (i % PACKETS_LIMIT == PACKETS_LIMIT - 1 ||
             sent_bytes[j] > (size_t)rcvbuf_val / 2)

--- a/sockapi-ts/level5/out_of_resources/out_of_resources.c
+++ b/sockapi-ts/level5/out_of_resources/out_of_resources.c
@@ -175,9 +175,7 @@ count_nic_addresses(const char *ta, const char *ifname, count_addrs_ctx *ctx)
     size_t       num;
     te_errno     rc;
 
-    rc = te_string_append(&ta_ifname, "%s/%s", ta, ifname);
-    if (rc != 0)
-        return rc;
+    te_string_append(&ta_ifname, "%s/%s", ta, ifname);
 
     if (tq_strings_add_uniq(&ctx->ifs, ta_ifname.ptr) != FALSE)
     {

--- a/sockapi-ts/lib/sockapi-ts_bpf.c
+++ b/sockapi-ts/lib/sockapi-ts_bpf.c
@@ -149,11 +149,7 @@ sockts_bpf_map_arr32_to_str(rcf_rpc_server *rpcs, char *ifname, unsigned int bpf
                        __FUNCTION__, rc);
         }
 
-        if ((rc = te_string_append(str, "%s%u(%d)", key == 0 ? "" :  ", ",
-                                   key, val)) != 0)
-        {
-            TEST_FAIL("%s() te_string_append() -> %r", __FUNCTION__, rc);
-        }
+        te_string_append(str, "%s%u(%d)", key == 0 ? "" :  ", ", key, val);
     }
 }
 
@@ -320,9 +316,7 @@ sockts_bpf_build_all(rcf_rpc_server *pco)
     if (rc != 0)
         return rc;
 
-    rc = te_string_append(&src_dir, "%s/%s", sapi_dir, SOCKTS_BPF_SRC_DIR);
-    if (rc != 0)
-        goto exit;
+    te_string_append(&src_dir, "%s/%s", sapi_dir, SOCKTS_BPF_SRC_DIR);
 
     rc = sockts_build_dir(pco, src_dir.ptr, ta_dir, FALSE);
     if (rc != 0)
@@ -353,9 +347,7 @@ sockts_bpf_build_stimuli(rcf_rpc_server *pco)
     if (rc != 0)
         return rc;
 
-    rc = te_string_append(&src_dir, "%s/%s", te_dir, "bpf");
-    if (rc != 0)
-        goto exit;
+    te_string_append(&src_dir, "%s/%s", te_dir, "bpf");
 
     rc = sockts_build_dir(pco, src_dir.ptr, ta_dir, FALSE);
     if (rc != 0)

--- a/sockapi-ts/lib/sockapi-ts_net_conns.c
+++ b/sockapi-ts/lib/sockapi-ts_net_conns.c
@@ -167,8 +167,7 @@ configure_macvlan_or_ipvlan_pair(
     sockts_allocate_network(&conn->net_handle, &conn->net_prefix,
                             af);
 
-    CHECK_RC(te_string_append(&if_name, "%svlan_%d",
-                              (macvlan ? "mac" : "ip"), if_id));
+    te_string_append(&if_name, "%svlan_%d", (macvlan ? "mac" : "ip"), if_id);
     conn->iut_new_if.if_name = if_name.ptr;
 
     if (macvlan)

--- a/sockapi-ts/lib/sockapi-ts_rpc.c
+++ b/sockapi-ts/lib/sockapi-ts_rpc.c
@@ -1963,50 +1963,43 @@ rpc_sockts_proc_zc_compl_queue(rcf_rpc_server *rpcs, rpc_ptr qhead,
  * @param mmsg      Pointer to structure.
  * @param str       Where to append string representation.
  *
- * @return Status code.
+ * @return 0
+ *
+ * @note The function never returns an error. Its return type is not void
+ *       for legacy reasons.
  */
 static te_errno
 onload_zc_mmsg_rpc2str(rcf_rpc_server *rpcs,
                        struct rpc_onload_zc_mmsg *mmsg, te_string *str)
 {
-    te_errno rc = 0;
     tarpc_size_t i;
 
-    rc = te_string_append(str, "{ ");
-    if (rc != 0)
-        return rc;
-
+    te_string_append(str, "{ ");
     msghdr_rpc2str(&mmsg->msg, str);
 
     if (mmsg->buf_specs != NULL)
     {
         tarpc_onload_zc_buf_spec *specs = mmsg->buf_specs;
 
-        rc = te_string_append(str, ", buf_specs = [");
-        if (rc != 0)
-            return rc;
+        te_string_append(str, ", buf_specs = [");
 
         for (i = 0; i < mmsg->msg.msg_riovlen; i++)
         {
             if (i > 0)
-            {
-                rc = te_string_append(str, ", ");
-                if (rc != 0)
-                    return rc;
-            }
+                te_string_append(str, ", ");
 
             switch (specs[i].type)
             {
                 case TARPC_ONLOAD_ZC_BUF_NEW_ALLOC:
-                    rc = te_string_append(str, "NEW_ALLOC");
+                    te_string_append(str, "NEW_ALLOC");
                     break;
 
                 case TARPC_ONLOAD_ZC_BUF_NEW_REG:
-                    rc = te_string_append(str, "NEW_REG");
+                    te_string_append(str, "NEW_REG");
                     break;
 
                 case TARPC_ONLOAD_ZC_BUF_EXIST_ALLOC:
-                    rc = te_string_append(
+                    te_string_append(
                           str,
                           "EXIST_ALLOC (buf = " RPC_PTR_FMT ", "
                           "index = %u)",
@@ -2015,7 +2008,7 @@ onload_zc_mmsg_rpc2str(rcf_rpc_server *rpcs,
                     break;
 
                 case TARPC_ONLOAD_ZC_BUF_EXIST_REG:
-                    rc = te_string_append(
+                    te_string_append(
                           str,
                           "EXIST_REG (buf = " RPC_PTR_FMT ", "
                           "offset = % " TE_PRINTF_64 "u)",
@@ -2024,38 +2017,26 @@ onload_zc_mmsg_rpc2str(rcf_rpc_server *rpcs,
                     break;
 
                 default:
-                    rc = te_string_append(str, "<UNKNOWN>");
+                    te_string_append(str, "<UNKNOWN>");
             }
-
-            if (rc != 0)
-                return rc;
         }
 
-        rc = te_string_append(str, "]");
-        if (rc != 0)
-            return rc;
+        te_string_append(str, "]");
     }
 
-    rc = te_string_append(str, ", keep_recv_bufs=%s, saved_recv_bufs="
+    te_string_append(str, ", keep_recv_bufs=%s, saved_recv_bufs="
                           RPC_PTR_FMT,
                           (mmsg->keep_recv_bufs ? "TRUE" : "FALSE"),
                           RPC_PTR_VAL(mmsg->saved_recv_bufs));
-    if (rc != 0)
-        return rc;
 
     if (mmsg->rc < 0)
-    {
-        rc = te_string_append(str, ", rc=-error:%s",
-                              errno_rpc2str(-mmsg->rc));
-    }
+        te_string_append(str, ", rc=-error:%s", errno_rpc2str(-mmsg->rc));
     else
-    {
-        rc = te_string_append(str, ", rc=%d", mmsg->rc);
-    }
-    if (rc != 0)
-        return rc;
+        te_string_append(str, ", rc=%d", mmsg->rc);
 
-    return te_string_append(str, ", fd=%d }", mmsg->fd);
+    te_string_append(str, ", fd=%d }", mmsg->fd);
+
+    return 0;
 }
 
 /**
@@ -2080,11 +2061,7 @@ onload_zc_mmsgs_rpc2str(rcf_rpc_server *rpcs,
     for (i = 0; i < mlen; i++)
     {
         if (i > 0)
-        {
-            rc = te_string_append(str, ", ");
-            if (rc != 0)
-                return rc;
-        }
+            te_string_append(str, ", ");
 
         rc = onload_zc_mmsg_rpc2str(rpcs, &msgs[i], str);
         if (rc != 0)
@@ -2276,11 +2253,7 @@ rpc_simple_zc_send_gen(rcf_rpc_server *rpcs,
             msgs[j].rc = out.zc_rc.zc_rc_val[j];
 
             if (j > 0)
-            {
-                rc = te_string_append(&str_msgs, ", ");
-                if (rc != 0)
-                    break;
-            }
+                te_string_append(&str_msgs, ", ");
 
             rc = onload_zc_mmsg_rpc2str(rpcs, &msgs[j], &str_msgs);
             if (rc != 0)

--- a/sockapi-ts/lib/sockapi-ts_target_build.c
+++ b/sockapi-ts/lib/sockapi-ts_target_build.c
@@ -175,39 +175,32 @@ sockts_build_dir(rcf_rpc_server *pco, const char *src_dir,
 
     if (build_on_engine)
     {
-        CHECK_ERRNO_RET((ret = te_string_append(&cmd, "make -C %s", src_dir)));
+        te_string_append(&cmd, "make -C %s", src_dir);
         CHECK_ERRNO_RET((ret = sockts_run_cmd(cmd.ptr)));
 
         te_string_reset(&cmd);
-        CHECK_ERRNO_RET((ret = te_string_append(&cmd, "cd %s && tar -cvzf %s "
-                                                "--exclude=%s *.o",
-                                                src_dir, SOCKTS_TMP_TGZ_NAME,
-                                                SOCKTS_TMP_TGZ_NAME)));
+        te_string_append(&cmd, "cd %s && tar -cvzf %s --exclude=%s *.o",
+                         src_dir, SOCKTS_TMP_TGZ_NAME, SOCKTS_TMP_TGZ_NAME);
         CHECK_ERRNO_RET(sockts_run_cmd(cmd.ptr));
     }
     else
     {
-        CHECK_ERRNO_RET((ret = te_string_append(&cmd, "cd %s && tar -cvzf %s "
-                                                "--exclude=%s *",
-                                                src_dir, SOCKTS_TMP_TGZ_NAME,
-                                                SOCKTS_TMP_TGZ_NAME)));
+        te_string_append(&cmd, "cd %s && tar -cvzf %s --exclude=%s *",
+                         src_dir, SOCKTS_TMP_TGZ_NAME, SOCKTS_TMP_TGZ_NAME);
         CHECK_ERRNO_RET((ret = sockts_run_cmd(cmd.ptr)));
     }
 
-    CHECK_ERRNO_RET((ret = te_string_append(&src_full, "%s/%s", src_dir,
-                                            SOCKTS_TMP_TGZ_NAME)));
-    CHECK_ERRNO_RET((ret = te_string_append(&dst, "%s/%s", dst_dir,
-                                            SOCKTS_TMP_TGZ_NAME)));
+    te_string_append(&src_full, "%s/%s", src_dir, SOCKTS_TMP_TGZ_NAME);
+    te_string_append(&dst, "%s/%s", dst_dir, SOCKTS_TMP_TGZ_NAME);
     CHECK_ERRNO_RET((ret = rcf_ta_put_file(pco->ta, 0, src_full.ptr, dst.ptr)));
 
     te_string_reset(&cmd);
-    CHECK_ERRNO_RET((ret = te_string_append(&cmd, "tar -C %s -xvzf %s",
-                                            dst_dir, dst.ptr)));
+    te_string_append(&cmd, "tar -C %s -xvzf %s", dst_dir, dst.ptr);
     CHECK_ERRNO_RET((ret = sockts_run_rpcs_cmd(pco, cmd.ptr, 0)));
     if (!build_on_engine)
     {
         te_string_reset(&cmd);
-        CHECK_ERRNO_RET((ret = te_string_append(&cmd, "make -C %s", dst_dir)));
+        te_string_append(&cmd, "make -C %s", dst_dir);
         CHECK_ERRNO_RET((ret = sockts_run_rpcs_cmd(pco,
                                                    cmd.ptr, TE_SEC2MS(300))));
     }
@@ -228,8 +221,7 @@ sockts_cleanup_build(const char *src_dir, te_bool build_on_engine)
 
     if (build_on_engine)
     {
-        CHECK_ERRNO_RET((ret = te_string_append(&cmd, "cd %s && make clean",
-                                                src_dir)));
+        te_string_append(&cmd, "cd %s && make clean", src_dir);
         CHECK_ERRNO_RET((ret = sockts_run_cmd(cmd.ptr)));
         te_string_free(&cmd);
     }
@@ -237,10 +229,9 @@ sockts_cleanup_build(const char *src_dir, te_bool build_on_engine)
     te_string_reset(&cmd);
     if (src_dir != NULL)
     {
-        CHECK_ERRNO_RET((ret = te_string_append(&cmd,
-                                                "test -f %s/%s && rm %s/%s",
-                                                src_dir, SOCKTS_TMP_TGZ_NAME,
-                                                src_dir, SOCKTS_TMP_TGZ_NAME)));
+        te_string_append(&cmd, "test -f %s/%s && rm %s/%s",
+                         src_dir, SOCKTS_TMP_TGZ_NAME,
+                         src_dir, SOCKTS_TMP_TGZ_NAME);
         CHECK_ERRNO_RET((ret = sockts_run_cmd(cmd.ptr)));
     }
 

--- a/sockapi-ts/performance/epilogue.c
+++ b/sockapi-ts/performance/epilogue.c
@@ -24,7 +24,7 @@ main(int argc, char *argv[])
     TEST_GET_PCO(pco_iut);
     TEST_GET_PCO(pco_tst);
 
-    CHECK_RC(te_string_append(&cmd, "pkill -f netserver"));
+    te_string_append(&cmd, "pkill -f netserver");
 
     if ((pid = rpc_te_shell_cmd(pco_tst, cmd.ptr, -1, NULL, NULL, NULL)) < 0)
         ERROR("Failed to kill netserver: %s", cmd);

--- a/sockapi-ts/performance/prologue.c
+++ b/sockapi-ts/performance/prologue.c
@@ -47,7 +47,7 @@ main(int argc, char *argv[])
     TEST_GET_PCO(pco_iut);
 
     /* We need to be sure that process of netserver does't exist */
-    CHECK_RC(te_string_append(&cmd, "pkill -f netserver"));
+    te_string_append(&cmd, "pkill -f netserver");
 
     CHECK_RC(tapi_onload_copy_sapi_ts_script(pco_iut, PATH_TO_TE_ONLOAD));
     if ((pid = rpc_te_shell_cmd(pco_tst, cmd.ptr, -1, NULL, NULL, NULL)) < 0)

--- a/sockapi-ts/prologue.c
+++ b/sockapi-ts/prologue.c
@@ -316,15 +316,14 @@ copy_onload_tools(rcf_rpc_server *pco_iut)
 
         if (zf_gnu != NULL && *zf_gnu != '\0')
         {
-            CHECK_RC(te_string_append(&zf_stackdump_path, "bin/%s",
-                     ZF_STACKDUMP_NAME));
+            te_string_append(&zf_stackdump_path, "bin/%s", ZF_STACKDUMP_NAME);
             copy_onload_tool(pco_iut->ta, zf_gnu, agt_dir,
                              zf_stackdump_path.ptr, ZF_STACKDUMP_NAME);
         }
         else if (onload_gnu != NULL && *onload_gnu != '\0')
         {
-            CHECK_RC(te_string_append(&zf_stackdump_path, "tools/zf/%s",
-                     ZF_STACKDUMP_NAME));
+            te_string_append(&zf_stackdump_path, "tools/zf/%s",
+                             ZF_STACKDUMP_NAME);
             copy_onload_tool(pco_iut->ta, onload_gnu, agt_dir,
                              zf_stackdump_path.ptr, ZF_STACKDUMP_NAME);
         }
@@ -506,17 +505,17 @@ copy_lib_for_zfshim()
     val_type = CVT_STRING;
     CHECK_RC(cfg_get_instance_fmt(&val_type, &agt_dir, "/agent:%s/dir:",
                                   ta));
-    CHECK_RC(te_string_append(&dst, "%s/libonload_zf.so.1", agt_dir));
+    te_string_append(&dst, "%s/libonload_zf.so.1", agt_dir);
 
     /*
      * Zetaferno has a separate repo after onload-8.0 release.
      * It must be taken into account when setting LD_LIBRARY_PATH.
      */
     if (zf_gnu != NULL && zf_gnu[0] != '\0')
-        CHECK_RC(te_string_append(&src, "%s/lib/", zf_gnu));
+        te_string_append(&src, "%s/lib/", zf_gnu);
     else
-        CHECK_RC(te_string_append(&src, "%s/lib/zf/", onload_gnu));
-    CHECK_RC(te_string_append(&src, "libonload_zf.so"));
+        te_string_append(&src, "%s/lib/zf/", onload_gnu);
+    te_string_append(&src, "libonload_zf.so");
 
     if ((rc = access(src.ptr, F_OK)) < 0)
     {
@@ -853,13 +852,7 @@ set_max_stacks_possible(rcf_rpc_server *rpcs, const char *ifname)
         return 0;
     }
 
-    rc = te_string_append(&max_stacks_s, "%d", max_stacks);
-    if (rc != 0)
-    {
-        ERROR("Failed to convert max_stack value "
-              "to its string representation: %r", rc);
-        return rc;
-    }
+    te_string_append(&max_stacks_s, "%d", max_stacks);
 
     rc = tapi_sh_env_get_int(rpcs, "SOCKTS_MAX_STACKS", &imp_stacks);
     if (rc != 0 || imp_stacks > max_stacks)

--- a/sockapi-ts/route/if_change_netns.c
+++ b/sockapi-ts/route/if_change_netns.c
@@ -199,7 +199,7 @@ check_connection(rcf_rpc_server *pco_iut, const struct if_nameindex *iut_if,
     if (rt_sock_type == SOCKTS_SOCK_UDP)
         rpc_connect(pco_tst, tst_s, SA(&iut_bind_addr));
 
-    CHECK_EXPR(te_string_append(&str, "%s, sending from IUT", msg));
+    te_string_append(&str, "%s, sending from IUT", msg);
     test_send_rc = sockts_rt_test_send(rt_sock_type, pco_iut, iut_s,
                                        pco_tst, tst_s,
                                        SA(&tst_bind_addr), NULL,
@@ -211,7 +211,7 @@ check_connection(rcf_rpc_server *pco_iut, const struct if_nameindex *iut_if,
     }
 
     te_string_reset(&str);
-    CHECK_EXPR(te_string_append(&str, "%s, sending from Tester", msg));
+    te_string_append(&str, "%s, sending from Tester", msg);
     test_send_rc = sockts_rt_test_send(rt_sock_type, pco_tst, tst_s,
                                        pco_iut, iut_s,
                                        SA(&iut_bind_addr), NULL,

--- a/sockapi-ts/route/lib/ts_route.c
+++ b/sockapi-ts/route/lib/ts_route.c
@@ -793,7 +793,7 @@ sockts_rt_one_sock_check_route(te_bool first_if,
 
     SOCKTS_RT_RING("Send data in both directions between IUT and Tester");
 
-    CHECK_RC(te_string_append(&err_str, "%s, sending from IUT", err_msg));
+    te_string_append(&err_str, "%s, sending from IUT", err_msg);
 
     test_send_rc = sockts_rt_test_send(rt_sock_type, pco_iut, *iut_s,
                                        pco_tst, *tst_s,
@@ -803,8 +803,7 @@ sockts_rt_one_sock_check_route(te_bool first_if,
         TEST_STOP;
 
     te_string_reset(&err_str);
-    CHECK_RC(te_string_append(&err_str, "%s, sending from Tester",
-                              err_msg));
+    te_string_append(&err_str, "%s, sending from Tester", err_msg);
 
     test_send_rc = sockts_rt_test_send(
                             (rt_sock_type == SOCKTS_SOCK_UDP ?

--- a/sockapi-ts/route/lib/ts_route_mpath.c
+++ b/sockapi-ts/route/lib/ts_route_mpath.c
@@ -233,18 +233,8 @@ tst_packets_handler(asn_value *pkt, void *userdata)
         WARN("Captured packet was not recognized");
     }
 
-    rc = te_string_append(&addrs_log, " with src=%s",
-                          sockaddr_h2str(SA(&src)));
-    if (rc == 0)
-    {
-        rc = te_string_append(&addrs_log, " dst=%s",
-                              sockaddr_h2str(SA(&dst)));
-    }
-    if (rc != 0)
-    {
-        ERROR("%s(): te_string_append() returned %r", __FUNCTION__, rc);
-        te_string_reset(&addrs_log);
-    }
+    te_string_append(&addrs_log, " with src=%s", sockaddr_h2str(SA(&src)));
+    te_string_append(&addrs_log, " dst=%s", sockaddr_h2str(SA(&dst)));
 
     if (!data->no_pkts_log)
     {
@@ -352,8 +342,8 @@ establish_connection(rcf_rpc_server *pco_iut, rcf_rpc_server *pco_tst,
     if (msg[0] != '\0')
     {
         va_start(ap, msg);
-        CHECK_RC(te_string_append_va(&str, msg, ap));
-        CHECK_RC(te_string_append(&str, ": "));
+        te_string_append_va(&str, msg, ap);
+        te_string_append(&str, ": ");
     }
 
     iut_s = *iut_s_ptr =
@@ -485,8 +475,8 @@ send_recv_data(te_bool from_tester,
     if (msg[0] != '\0')
     {
         va_start(ap, msg);
-        CHECK_RC(te_string_append_va(&str, msg, ap));
-        CHECK_RC(te_string_append(&str, ": "));
+        te_string_append_va(&str, msg, ap);
+        te_string_append(&str, ": ");
     }
 
     for (i = 0; i < pkts_num; i++)

--- a/sockapi-ts/route/pbr_oif_src.c
+++ b/sockapi-ts/route/pbr_oif_src.c
@@ -72,7 +72,7 @@ compare_src_addr(const struct sockaddr *exp_addr,
     va_list     ap;
 
     va_start(ap, format);
-    CHECK_RC(te_string_append_va(&str, format, ap));
+    te_string_append_va(&str, format, ap);
     va_end(ap);
 
     if (te_sockaddrcmp_no_ports(real_addr, real_addr_len,

--- a/sockapi-ts/signal/ts_signal.c
+++ b/sockapi-ts/signal/ts_signal.c
@@ -35,9 +35,9 @@ set_sighandler(rcf_rpc_server *rpcs, rpc_signum sig,
 {
     te_string prefix = TE_STRING_INIT;
 
-    CHECK_RC(te_string_append(&prefix, ""));
+    te_string_append(&prefix, "");
     if (vpref != NULL)
-        CHECK_RC(te_string_append(&prefix, "%s: ", vpref));
+        te_string_append(&prefix, "%s: ", vpref);
 
     if (old_act != NULL)
         rpc_sigaction_reinit(rpcs, old_act);

--- a/sockapi-ts/sockopts/max_bufs.c
+++ b/sockapi-ts/sockopts/max_bufs.c
@@ -91,10 +91,8 @@ set_sock_buf(rcf_rpc_server *rpcs, int s, rpc_sockopt opt,
     va_list ap;
 
     va_start(ap, err_msg);
-    rc = te_string_append_va(&stage, err_msg, ap);
+    te_string_append_va(&stage, err_msg, ap);
     va_end(ap);
-    if (rc != 0)
-        TEST_FAIL("%s(): failed to construct stage string", __FUNCTION__);
 
     RPC_AWAIT_ERROR(rpcs);
     rc = rpc_setsockopt_int(rpcs, s, opt, set_val);

--- a/sockapi-ts/sockopts/rcvbuf_stream.c
+++ b/sockapi-ts/sockopts/rcvbuf_stream.c
@@ -284,9 +284,8 @@ main(int argc, char *argv[])
     memset(&curr, 0, sizeof(curr));
     curr.rcvbuf = 10;
 
-    CHECK_RC(te_string_append(&str, "%20s %20s %20s %20s %10s\n",
-                              "RCVBUF", "RATIO", "READ", "RATIO",
-                              "RESULT"));
+    te_string_append(&str, "%20s %20s %20s %20s %10s\n",
+                     "RCVBUF", "RATIO", "READ", "RATIO", "RESULT");
 
     for (i = 0; i < MAX_ITER_NUM; i++)
     {
@@ -344,10 +343,10 @@ main(int argc, char *argv[])
             }
         }
 
-        CHECK_RC(te_string_append(&str, "%20d %20.3f %20d %20.3f %10s\n",
+        te_string_append(&str, "%20d %20.3f %20d %20.3f %10s\n",
                                   curr.rcvbuf, rcvbuf_ratio,
                                   curr.filled, filled_ratio,
-                                  (fail ? "FAIL" : "PASS")));
+                                  (fail ? "FAIL" : "PASS"));
 
         if (prev.rcvbuf == curr.rcvbuf ||
             curr.rcvbuf >= rcvbuf_max * 2)

--- a/sockapi-ts/sockopts/tcp_nodelay.c
+++ b/sockapi-ts/sockopts/tcp_nodelay.c
@@ -230,13 +230,13 @@ check_nodelay(rcf_rpc_server *pco_iut, int iut_s,
 
     te_fill_buf(tx_buf, sizeof(tx_buf));
 
-    CHECK_RC(te_string_append(&str, "%s, sending the first packet", msg));
+    te_string_append(&str, "%s, sending the first packet", msg);
     send_recv_pkt(pco_iut, iut_s, tcp_conn, &tx_buf[0], 1, str.ptr);
     process_csap_pkts(csap_ta, csap, &user_data, str.ptr);
     ts1 = user_data.ts;
 
     te_string_reset(&str);
-    CHECK_RC(te_string_append(&str, "%s, sending the second packet", msg));
+    te_string_append(&str, "%s, sending the second packet", msg);
     send_recv_pkt(pco_iut, iut_s, tcp_conn, &tx_buf[1], 1, str.ptr);
     process_csap_pkts(csap_ta, csap, &user_data, str.ptr);
     ts2 = user_data.ts;

--- a/sockapi-ts/tcp/diff_tuple_diff_isn.c
+++ b/sockapi-ts/tcp/diff_tuple_diff_isn.c
@@ -593,8 +593,7 @@ main(int argc, char *argv[])
         if (!conns[i].isn_captured)
             TEST_VERDICT("For some connections ISN was not captured");
 
-        CHECK_RC(te_string_append(&str, "conns[%u].ISN = %u\n",
-                                  i, conns[i].isn));
+        te_string_append(&str, "conns[%u].ISN = %u\n", i, conns[i].isn);
     }
     RING("Obtained ISNs:\n%s", str.ptr);
 
@@ -609,10 +608,7 @@ main(int argc, char *argv[])
     for (i = 0; i < TEST_CONNS_NUM; i++)
     {
         if (conns[i].max_mark == diff_metric)
-        {
-            CHECK_RC(te_string_append(&str, "conns[%u].ISN = %u\n",
-                                      i, conns[i].isn));
-        }
+            te_string_append(&str, "conns[%u].ISN = %u\n", i, conns[i].isn);
     }
     RING("The longest list of connections with close ISN values:\n%s",
          str.ptr);

--- a/sockapi-ts/tcp/ts_send.c
+++ b/sockapi-ts/tcp/ts_send.c
@@ -73,17 +73,12 @@ append_flags_descr(uint32_t flags, te_string *str)
 
 #define CHECK_FLAG(_flags, _f, _s) \
     do {                                                  \
-        te_errno _rc;                                     \
-                                                          \
         if (_flags & TCP_ ## _f ## _FLAG)                 \
         {                                                 \
             if (added_flag)                               \
-                _rc = te_string_append(_s, "|%s", #_f);   \
+                te_string_append(_s, "|%s", #_f);         \
             else                                          \
-                _rc = te_string_append(_s, "%s", #_f);    \
-                                                          \
-            if (_rc != 0)                                 \
-                return _rc;                               \
+                te_string_append(_s, "%s", #_f);          \
                                                           \
             added_flag = TRUE;                            \
         }                                                 \
@@ -95,7 +90,7 @@ append_flags_descr(uint32_t flags, te_string *str)
     CHECK_FLAG(flags, ACK, str);
 
     if (!added_flag)
-        return te_string_append(str, "no");
+        te_string_append(str, "no");
 
     return 0;
 #undef CHECK_FLAG
@@ -155,15 +150,14 @@ pkt_handler(asn_value *pkt, void *user_data)
     CB_CHECK_RC(asn_read_uint32(pkt, &flags, "pdus.0.#tcp.flags"));
     CB_CHECK_RC(tapi_tcp_get_hdrs_payload_len(pkt, NULL, &payload_len));
 
-    CB_CHECK_RC(te_string_append(&pkt_descr, "packet with "));
+    te_string_append(&pkt_descr, "packet with ");
     CB_CHECK_RC(append_flags_descr(flags, &pkt_descr));
-    CB_CHECK_RC(te_string_append(&pkt_descr, " flag(s)"));
+    te_string_append(&pkt_descr, " flag(s)");
 
     if (payload_len > 0)
-        CB_CHECK_RC(te_string_append(&pkt_descr, " and payload"));
+        te_string_append(&pkt_descr, " and payload");
 
-    CB_CHECK_RC(te_string_append(&pkt_descr, " sent from %s",
-                                 pkt_source));
+    te_string_append(&pkt_descr, " sent from %s", pkt_source);
 
     rc = tapi_tcp_get_ts_opt(pkt, &ts_value, &ts_echo);
     if (rc != 0)

--- a/sockapi-ts/timestamps/timestamps.c
+++ b/sockapi-ts/timestamps/timestamps.c
@@ -274,11 +274,11 @@ ts_print_msg_control_data(rpc_msghdr *msghdr)
     struct msghdr              msg;
     te_string                  str = TE_STRING_BUF_INIT(buf);
 
-    CHECK_RC(te_string_append(&str, "Control data: "));
+    te_string_append(&str, "Control data: ");
 
     if (msghdr->msg_controllen == 0)
     {
-        CHECK_RC(te_string_append(&str, "none"));
+        te_string_append(&str, "none");
         RING("%s", str.ptr);
         return;
     }
@@ -292,13 +292,13 @@ ts_print_msg_control_data(rpc_msghdr *msghdr)
          cmsg = CMSG_NXTHDR(&msg, cmsg))
     {
         if (cmsg != CMSG_FIRSTHDR(&msg))
-            CHECK_RC(te_string_append(&str, ", "));
+            te_string_append(&str, ", ");
 
-        CHECK_RC(te_string_append(&str, "level=%d type=%d (%s)",
+        te_string_append(&str, "level=%d type=%d (%s)",
                                   cmsg->cmsg_level, cmsg->cmsg_type,
                                    sockopt_rpc2str(
                                         cmsg_type_h2rpc(cmsg->cmsg_level,
-                                                        cmsg->cmsg_type))));
+                                                        cmsg->cmsg_type)));
     }
 
     RING("%s", str.ptr);

--- a/talib_sockapi_ts/parse_orm_json.c
+++ b/talib_sockapi_ts/parse_orm_json.c
@@ -133,9 +133,7 @@ ta_read_cmd(const char *cmd, te_string *str)
         }
         buf[sys_rc] = '\0';
 
-        rc = te_string_append(str, "%s", buf);
-        if (rc != 0)
-            goto cleanup;
+        te_string_append(str, "%s", buf);
     }
 
 cleanup:

--- a/talib_sockapi_ts/rpc.c
+++ b/talib_sockapi_ts/rpc.c
@@ -9542,15 +9542,13 @@ tcp_get_state_from_tool(const char *tool,
      * removes from string everything except the last word which
      * is assumed to be TCP state name.
      */
-    res = te_string_append(
+    te_string_append(
               &cmd,
               "%s | grep \"[^0-9]\\[\\?%s\\]\\?:%hu"
               "\\(\\s.*[^0-9]\\|\\s\\+\\)\\[\\?%s\\]\\?:%hu\\s\\+\" | "
               "sed \"s/^.*\\s\\([^[:space:]]\\+\\)\\s*\\$/\\1/\"",
               tool, loc_addr_str, ntohs(te_sockaddr_get_port(loc_addr)),
               rem_addr_str, ntohs(te_sockaddr_get_port(rem_addr)));
-    if (res != 0)
-        goto cleanup;
 
     res = ta_popen_r(cmd.ptr, &cmd_pid, &f);
     if (res != 0)
@@ -9766,7 +9764,10 @@ tcp_get_state(struct sockaddr *loc_addr, struct sockaddr *rem_addr,
  * @param path        Format string for path.
  * @param ...         Parameters for format string.
  *
- * @return Status code.
+ * @return 0
+ *
+ * @note The function never returns an error. Its return type is not void
+ *       for legacy reasons.
  */
 static te_errno
 check_program_exists(bool *exists, const char *path, ...)
@@ -9779,15 +9780,8 @@ check_program_exists(bool *exists, const char *path, ...)
     *exists = FALSE;
 
     va_start(ap, path);
-    rc = te_string_append_va(&str, path, ap);
+    te_string_append_va(&str, path, ap);
     va_end(ap);
-
-    if (rc != 0)
-    {
-        ERROR("%s(): te_string_append_va() failed, %r",
-              __FUNCTION__, rc);
-        return rc;
-    }
 
     if (access(str.ptr, X_OK) == 0)
         *exists = TRUE;
@@ -9834,11 +9828,8 @@ find_netstat_tools(bool *orm_json, bool *onload_stdump,
     {
         int retval;
 
-        rc = te_string_append(&str,
-                              "%s/te_onload_stdump -z netstat "
-                              "| grep \"unknown command\"", ta_dir);
-        if (rc != 0)
-            return rc;
+        te_string_append(&str, "%s/te_onload_stdump -z netstat "
+                         "| grep \"unknown command\"", ta_dir);
 
         retval = ta_system(str.ptr);
 


### PR DESCRIPTION
Remove the return code checks from the te_string*() functions (which always return 0), because it is planned to change their signatures in TE repository.

OL-Redmine-Id: 14677

-------------
Build test suite - OK.
