### PR TITLE
Disable on netns sockopts/max_bufs and sockopts/setbuf_force

### DIFF
--- a/sockapi-ts/sockopts/package.xml
+++ b/sockapi-ts/sockopts/package.xml
@@ -3588,6 +3588,9 @@
         <run>
             <script name="setbuf_force">
               <req ref="opt_name"/>
+              <!-- Onload can't obtain rmem_max/wmem_max from
+                   the main namespace. See ON-12805 -->
+              <req id="NO_NETNS"/>
             </script>
             <arg name="env">
                 <value ref="env.iut_only"/>

--- a/trc/trc-sockapi-ts-sockopts.xml
+++ b/trc/trc-sockapi-ts-sockopts.xml
@@ -23222,32 +23222,8 @@
         <arg name="domain"/>
         <arg name="env"/>
         <arg name="opt_name"/>
-        <arg name="sock_type">SOCK_DGRAM</arg>
+        <arg name="sock_type"/>
         <notes/>
-      </iter>
-      <iter result="PASSED">
-        <arg name="domain"/>
-        <arg name="env"/>
-        <arg name="opt_name">SO_SNDBUFFORCE</arg>
-        <arg name="sock_type">SOCK_STREAM</arg>
-        <notes/>
-        <results tags="v5" key="ON-8252">
-          <result value="PASSED">
-            <verdict>setsockopt(SO_SNDBUF) allowed to set value bigger than system maximum</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="domain"/>
-        <arg name="env"/>
-        <arg name="opt_name">SO_RCVBUFFORCE</arg>
-        <arg name="sock_type">SOCK_STREAM</arg>
-        <notes/>
-        <results tags="v5" key="ON-8252">
-          <result value="PASSED">
-            <verdict>setsockopt(SO_RCVBUF) allowed to set value bigger than system maximum</verdict>
-          </result>
-        </results>
       </iter>
     </test>
     <test name="ipv6_only_bind" type="script">


### PR DESCRIPTION
```
../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=af_xdp --ool=netns_all --tester-run=sockapi-ts/sockopts/setbuf_force
```
all is green.
```
../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=af_xdp --ool=netns_all --tester-run=sockapi-ts/sockopts/max_bufs
```
There are some fails just like in main branch:
```
RING  sockopts/max_bufs  TAPI RPC  16:24:40.248
RPC (Agt_A,pco_iut[8]): setsockopt(8, SOL_SOCKET, SO_RCVBUF, 212991, AUTO) -> 0 (OK)

RING  sockopts/max_bufs  TAPI RPC  16:24:40.249
RPC (Agt_A,pco_iut[9]): getsockopt(8, SOL_SOCKET, SO_RCVBUF, 0x7ffdbbde425c, AUTO) -> 0 optval=212992 r
aw_optlen=-1 (OK)

RING  sockopts/max_bufs  Verdict  16:24:40.249
When setting the buffer size to less than maximum value, retrieved value was not multiplied by two

ERROR  sockopts/max_bufs  Self  16:24:40.249
Expected value is 212991, obtained value is 212992
```
No runs with `--ool=netns_all`