### PR TITLE
sockopts/default_bufs: fix TRC for new kernels and netns

### DIFF
--- a/sockapi-ts/sockopts/default_bufs.c
+++ b/sockapi-ts/sockopts/default_bufs.c
@@ -76,11 +76,15 @@
 
 #define SET_AND_CHECK(def_, val_) \
     do {                                                            \
+        int rc;                                                     \
+                                                                    \
         /* Decrease system wide snd/rcv buffer max value */         \
         val_ /= 2;                                                  \
         RING("Attempt to set %s to %d", def_, val_);                \
-        CHECK_RC(tapi_cfg_sys_ns_set_int(pco_native->ta, val_,      \
-                                         NULL, def_));              \
+        rc = tapi_cfg_sys_ns_set_int(pco_native->ta, val_, NULL,    \
+                                     def_);                         \
+        if (rc != 0)                                                \
+            TEST_VERDICT("Failed to set %s", def_);                 \
         changed_ ## val_ = TRUE;                                    \
         /* Check that system wide values set correctly */           \
         CHECK_RC(tapi_cfg_sys_ns_get_int(pco_native->ta, &def_aux,  \

--- a/trc/trc-sockapi-ts-sockopts.xml
+++ b/trc/trc-sockapi-ts-sockopts.xml
@@ -19948,6 +19948,11 @@
             <verdict>(bound pco_iut socket) SO_RCVBUF default socket option value differentiates from system wide one</verdict>
           </result>
         </results>
+        <results tags="(netns_iut|netns_all)&amp;(linux&amp;(linux&gt;6|linux-6&gt;=12))" key="ON-7537">
+          <result value="FAILED">
+            <verdict>Failed to set net/core/wmem_default</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="change_val">TRUE</arg>


### PR DESCRIPTION
From 6.12 /proc/sys/net/core/wmem_default can't be changed on netns.


Reviewed-by: Viacheslav Galaktionov <viacheslav.galaktionov@arknetworks.am>
Tested on on 6.4.0-0.deb12.2-amd64 and 6.12.48+deb13-amd64:
```
../cns-sapi-ts/run.sh --cfg=... --tester-run=sockapi-ts/sockopts/default_bufs
../cns-sapi-ts/run.sh --cfg=... --ool=netns_iut --tester-run=sockapi-ts/sockopts/default_bufs
../cns-sapi-ts/run.sh --cfg=... --ool=netns_all --tester-run=sockapi-ts/sockopts/default_bufs
../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=netns_all --tester-run=sockapi-ts/sockopts/default_bufs
../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=netns_iut --tester-run=sockapi-ts/sockopts/default_bufs
```